### PR TITLE
Concise README, and change `IAgenticaTokenUsage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,25 @@
 [![Downloads](https://img.shields.io/npm/dm/@agentica/core.svg)](https://www.npmjs.com/package/@agentica/core)
 [![Build Status](https://github.com/wrtnlabs/agentica/workflows/build/badge.svg)](https://github.com/wrtnlabs/agentica/actions?query=workflow%3Abuild)
 
-The simplest Agentic AI library, specialized in **LLM function calling**.
+The simplest **Agentic AI** library, specialized in **LLM Function Calling**.
 
-`@agentica` is the simplest AI agent library specialized for LLM (Large Language Model) function calling. You can provide functions to call by *Swagger/OpenAPI* document or *TypeScript class type*, and it will make everything possible. *Super AI Chatbot* development, or *Multi-Agent Orchestration*, all of them can be realized by the function calling.
+Just deliver **Swagger/OpenAPI** document or **TypeScript class type** to the `agentica`. Then `agentica` will do everything.
 
-For example, if you provide **Swagger document** of a Shopping Mall Server, `@agentica` will compose **Super AI Chatbot** application. In the chatbot application, customers can purchase products just by conversation texts. If you wanna automate the counseling or refunding process, you also can do it just by delivering the Swagger document.
-
-Also, the LLM function calling strategy is effective for the **Multi-Agent Orchestration**, and it is easier to develop than any other way. You don't need to learn any complicate framework and its specific paradigms and patterns. Just connect them through class, and deliver the **TypeScript class type**. `@agentica` will centralize and realize the multi-agent orchestration through function calling.
+Look at the below demonstration, and feel how `agentica` is easy and powerful.
 
 ```typescript
-import { Agentica, createHttpLlmApplication } from "@agentica/core";
-import { OpenApi } from "@samchon/openapi";
+import typia from "typia";
+import { Agentica } from "@agentica/core";
 
-const document: OpenApi.IDocument;
 const agent: Agentica = new Agentica({
   controllers: [
-    {
-      name: "shopping",
-      application: createHttpLlmApplication({
-        model: "chatgpt",
-        document,
-      }),
-      connection: {
-        host: "http://localhost:3000",
-      },
-    },
+    await fetch(
+      "https://shopping-be.wrtn.ai/editor/swagger.json",
+    ).then(r => r.json()),
+    typia.llm.application<ShoppingCounselor>(),
+    typia.llm.application<ShoppingPolicy>(),
+    typia.llm.application<ShoppingSearchRag>(),
   ],
-  ...
 });
 await agent.conversate("I wanna buy MacBook Pro");
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@agentica/station",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Agentic AI library specialized in LLM Function Calling",
   "engines": {
     "pnpm": ">=8"

--- a/packages/core/src/internal/AgenticaTokenUsageAggregator.ts
+++ b/packages/core/src/internal/AgenticaTokenUsageAggregator.ts
@@ -69,7 +69,7 @@ export namespace AgenticaTokenUsageAggregator {
       a: IAgenticaTokenUsage.IComponent<Kind>,
       b: IAgenticaTokenUsage.IComponent<Kind>,
     ): IAgenticaTokenUsage.IComponent<Kind> => ({
-      kind: a.kind,
+      type: a.type,
       total: a.total + b.total,
       input: {
         total: a.input.total + b.input.total,
@@ -98,7 +98,7 @@ export namespace AgenticaTokenUsageAggregator {
     const component = <Kind extends string>(
       kind: Kind,
     ): IAgenticaTokenUsage.IComponent<Kind> => ({
-      kind,
+      type: kind,
       total: 0,
       input: {
         total: 0,

--- a/packages/core/src/structures/IAgenticaTokenUsage.ts
+++ b/packages/core/src/structures/IAgenticaTokenUsage.ts
@@ -48,11 +48,11 @@ export interface IAgenticaTokenUsage {
   describe: IAgenticaTokenUsage.IComponent<"describe">;
 }
 export namespace IAgenticaTokenUsage {
-  export interface IComponent<Kind extends string> {
+  export interface IComponent<Type extends string> {
     /**
-     * Kind of the token usage.
+     * Discriminator type.
      */
-    kind: Kind;
+    type: Type;
 
     /**
      * Total token usage.


### PR DESCRIPTION
This pull request includes various updates to the `agentica` project, focusing on improving documentation, updating package versions, and renaming properties for clarity. The most significant changes are summarized below:

Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-L35): Enhanced the description of the `agentica` library for better clarity and readability, including a more concise explanation of its capabilities and a simplified code example.

Version Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version of the `@agentica/station` package from `0.8.0` to `0.8.1`.

Property Renaming for Clarity:
* [`packages/core/src/internal/AgenticaTokenUsageAggregator.ts`](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL72-R72): Renamed the `kind` property to `type` in the `IAgenticaTokenUsage.IComponent` interface to improve clarity. [[1]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL72-R72) [[2]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL101-R101)
* [`packages/core/src/structures/IAgenticaTokenUsage.ts`](diffhunk://#diff-099346ce94c33aa3619deb1298d06bd45ba60b4c1aade4f0c3be320f56154c63L51-R55): Updated the `IAgenticaTokenUsage.IComponent` interface to use `type` instead of `kind` for the discriminator property.