### PR TITLE
Fix `IAgenticaTokenUsage.IElement` type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@agentica/station",
-  "version": "0.8.2",
+  "version": "0.8.3-dev.20250227",
   "description": "Agentic AI library specialized in LLM Function Calling",
   "engines": {
     "pnpm": ">=8"

--- a/packages/benchmark/src/internal/AgenticaCallBenchmarkReporter.ts
+++ b/packages/benchmark/src/internal/AgenticaCallBenchmarkReporter.ts
@@ -31,8 +31,7 @@ export namespace AgenticaCallBenchmarkReporter {
       events
         .map((e) => e.completed_at.getTime() - e.started_at.getTime())
         .reduce((a, b) => a + b, 0) / events.length;
-    const aggregate: IAgenticaTokenUsage.IComponent<"aggregate"> =
-      result.usage.aggregate;
+    const aggregate: IAgenticaTokenUsage.IComponent = result.usage.aggregate;
     return [
       "# LLM Function Call Benchmark",
       "## Summary",

--- a/packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts
+++ b/packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts
@@ -33,8 +33,7 @@ export namespace AgenticaSelectBenchmarkReporter {
       events
         .map((e) => e.completed_at.getTime() - e.started_at.getTime())
         .reduce((a, b) => a + b, 0) / events.length;
-    const aggregate: IAgenticaTokenUsage.IComponent<"aggregate"> =
-      result.usage.aggregate;
+    const aggregate: IAgenticaTokenUsage.IComponent = result.usage.aggregate;
     return [
       "# LLM Function Selection Benchmark",
       "## Summary",
@@ -88,8 +87,7 @@ export namespace AgenticaSelectBenchmarkReporter {
   const writeExperimentIndex = (
     exp: IAgenticaSelectBenchmarkResult.IExperiment,
   ): string => {
-    const aggregate: IAgenticaTokenUsage.IComponent<"aggregate"> =
-      exp.usage.aggregate;
+    const aggregate: IAgenticaTokenUsage.IComponent = exp.usage.aggregate;
     return [
       `# ${exp.scenario.name}`,
       "## Summary",

--- a/packages/core/src/Agentica.ts
+++ b/packages/core/src/Agentica.ts
@@ -216,9 +216,7 @@ export class Agentica {
       prompt: props.prompt,
 
       // HANDLERS
-      dispatch: async (event: IAgenticaEvent) => {
-        await this.dispatch(event);
-      },
+      dispatch: (event) => this.dispatch(event),
       request: async (kind, body) => {
         // request information
         const event: IAgenticaEvent.IRequest = {
@@ -302,7 +300,7 @@ export class Agentica {
 
   private async dispatch<Event extends IAgenticaEvent>(
     event: Event,
-  ): Promise<this> {
+  ): Promise<void> {
     const set = this.listeners_.get(event.type);
     if (set) {
       await Promise.all(
@@ -316,7 +314,5 @@ export class Agentica {
         }),
       );
     }
-
-    return this;
   }
 }

--- a/packages/core/src/internal/AgenticaTokenUsageAggregator.ts
+++ b/packages/core/src/internal/AgenticaTokenUsageAggregator.ts
@@ -13,8 +13,7 @@ export namespace AgenticaTokenUsageAggregator {
     //----
     // COMPONENT
     //----
-    const component: IAgenticaTokenUsage.IComponent<any> =
-      props.usage[props.kind];
+    const component: IAgenticaTokenUsage.IComponent = props.usage[props.kind];
 
     // TOTAL
     component.total += props.completion.usage.total_tokens;
@@ -39,15 +38,12 @@ export namespace AgenticaTokenUsageAggregator {
     //----
     // RE-AGGREGATE
     //----
-    const sum = (
-      getter: (comp: IAgenticaTokenUsage.IComponent<any>) => number,
-    ) =>
+    const sum = (getter: (comp: IAgenticaTokenUsage.IComponent) => number) =>
       Object.entries(props.usage)
         .filter(([key]) => key !== "aggregate")
         .map(([_, comp]) => getter(comp))
         .reduce((a, b) => a + b, 0);
-    const aggregate: IAgenticaTokenUsage.IComponent<"aggregate"> =
-      props.usage.aggregate;
+    const aggregate: IAgenticaTokenUsage.IComponent = props.usage.aggregate;
     aggregate.total = sum((comp) => comp.total);
     aggregate.input.total = sum((comp) => comp.input.total);
     aggregate.input.cached = sum((comp) => comp.input.cached);
@@ -65,11 +61,10 @@ export namespace AgenticaTokenUsageAggregator {
     x: IAgenticaTokenUsage,
     y: IAgenticaTokenUsage,
   ): IAgenticaTokenUsage => {
-    const component = <Kind extends string>(
-      a: IAgenticaTokenUsage.IComponent<Kind>,
-      b: IAgenticaTokenUsage.IComponent<Kind>,
-    ): IAgenticaTokenUsage.IComponent<Kind> => ({
-      type: a.type,
+    const component = (
+      a: IAgenticaTokenUsage.IComponent,
+      b: IAgenticaTokenUsage.IComponent,
+    ): IAgenticaTokenUsage.IComponent => ({
       total: a.total + b.total,
       input: {
         total: a.input.total + b.input.total,
@@ -95,10 +90,7 @@ export namespace AgenticaTokenUsageAggregator {
   };
 
   export const zero = (): IAgenticaTokenUsage => {
-    const component = <Kind extends string>(
-      kind: Kind,
-    ): IAgenticaTokenUsage.IComponent<Kind> => ({
-      type: kind,
+    const component = (): IAgenticaTokenUsage.IComponent => ({
       total: 0,
       input: {
         total: 0,
@@ -112,12 +104,12 @@ export namespace AgenticaTokenUsageAggregator {
       },
     });
     return {
-      aggregate: component("aggregate"),
-      initialize: component("initialize"),
-      select: component("select"),
-      cancel: component("cancel"),
-      call: component("call"),
-      describe: component("describe"),
+      aggregate: component(),
+      initialize: component(),
+      select: component(),
+      cancel: component(),
+      call: component(),
+      describe: component(),
     };
   };
 }

--- a/packages/core/src/structures/IAgenticaTokenUsage.ts
+++ b/packages/core/src/structures/IAgenticaTokenUsage.ts
@@ -20,40 +20,35 @@ export interface IAgenticaTokenUsage {
   /**
    * Aggregated token usage.
    */
-  aggregate: IAgenticaTokenUsage.IComponent<"aggregate">;
+  aggregate: IAgenticaTokenUsage.IComponent;
 
   /**
    * Token uasge of initializer agent.
    */
-  initialize: IAgenticaTokenUsage.IComponent<"initialize">;
+  initialize: IAgenticaTokenUsage.IComponent;
 
   /**
    * Token usage of function selector agent.
    */
-  select: IAgenticaTokenUsage.IComponent<"select">;
+  select: IAgenticaTokenUsage.IComponent;
 
   /**
    * Token usage of function canceler agent.
    */
-  cancel: IAgenticaTokenUsage.IComponent<"cancel">;
+  cancel: IAgenticaTokenUsage.IComponent;
 
   /**
    * Token usage of function caller agent.
    */
-  call: IAgenticaTokenUsage.IComponent<"call">;
+  call: IAgenticaTokenUsage.IComponent;
 
   /**
    * Token usage of function calling describer agent.
    */
-  describe: IAgenticaTokenUsage.IComponent<"describe">;
+  describe: IAgenticaTokenUsage.IComponent;
 }
 export namespace IAgenticaTokenUsage {
-  export interface IComponent<Type extends string> {
-    /**
-     * Discriminator type.
-     */
-    type: Type;
-
+  export interface IComponent {
     /**
      * Total token usage.
      */


### PR DESCRIPTION
This pull request includes several changes to the `Agentica` project, focusing on simplifying type usage and improving the dispatch method. The most important changes include updating the version in `package.json`, removing unnecessary type parameters from `IAgenticaTokenUsage.IComponent`, and modifying the `dispatch` method in the `Agentica` class.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `0.8.2` to `0.8.3-dev.20250227`.

### Type Simplification:
* [`packages/benchmark/src/internal/AgenticaCallBenchmarkReporter.ts`](diffhunk://#diff-fffe976f881c05bf47131ecaf587c9a6e9289fe6f106bb1a7703a888e1145b21L34-R34): Removed unnecessary type parameter from `IAgenticaTokenUsage.IComponent`.
* [`packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts`](diffhunk://#diff-8759e5db5d9c02ac643aaba52c04b9ddd16ed7d98a099c1bc6ac8da3cca228bdL36-R36): Removed unnecessary type parameter from `IAgenticaTokenUsage.IComponent`. [[1]](diffhunk://#diff-8759e5db5d9c02ac643aaba52c04b9ddd16ed7d98a099c1bc6ac8da3cca228bdL36-R36) [[2]](diffhunk://#diff-8759e5db5d9c02ac643aaba52c04b9ddd16ed7d98a099c1bc6ac8da3cca228bdL91-R90)
* [`packages/core/src/internal/AgenticaTokenUsageAggregator.ts`](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL16-R16): Simplified the type usage by removing the type parameter from `IAgenticaTokenUsage.IComponent`. [[1]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL16-R16) [[2]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL42-R46) [[3]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL68-R67) [[4]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL98-R93) [[5]](diffhunk://#diff-9e52b4fbd22c31b94eb88b47513568cb563122852602e7cfa679df747723342dL115-R112)
* [`packages/core/src/structures/IAgenticaTokenUsage.ts`](diffhunk://#diff-099346ce94c33aa3619deb1298d06bd45ba60b4c1aade4f0c3be320f56154c63L23-R51): Removed the type parameter from `IAgenticaTokenUsage.IComponent`.

### Dispatch Method Improvement:
* [`packages/core/src/Agentica.ts`](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L219-R219): Simplified the `dispatch` method by removing the async wrapper and changing the return type from `Promise<this>` to `Promise<void>`. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L219-R219) [[2]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L305-R303) [[3]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L319-L320)