### PR TITLE
feat: Agnetica should support third party cloud hosting

### DIFF
--- a/packages/core/src/structures/IAgenticaProvider.ts
+++ b/packages/core/src/structures/IAgenticaProvider.ts
@@ -34,8 +34,10 @@ export namespace IAgenticaProvider {
 
     /**
      * Chat model to be used.
+     *
+     * `({}) & string` means to support third party hosting cloud(eg. openRouter, aws)
      */
-    model: OpenAI.ChatModel;
+    model: OpenAI.ChatModel | ({} & string);
 
     /**
      * Options for the request.


### PR DESCRIPTION
example: https://openrouter.ai/google/gemini-2.0-flash-lite-001/api

Sometimes you use the open ai form as an API gateway.

So we will be not going to limit the model to Chatgpt
Format must be limited to chatgpt.