### PR TITLE
LLM service provider becomes vendor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import { Agentica } from "@agentica/core";
 import typia from "typia";
 
 const agent = new Agentica({
-  controllers: [
+  providers: [
     await fetch(
       "https://shopping-be.wrtn.ai/editor/swagger.json",
     ).then(r => r.json()),

--- a/articles/new-backend-development-paradigm-in-the-new-ai-era.md
+++ b/articles/new-backend-development-paradigm-in-the-new-ai-era.md
@@ -59,7 +59,7 @@ flowchart
 
 I made a library [`@samchon/openapi`](https://github.com/samchon/openapi) converting Swagger document to the LLM function calling schemas.
 
-It supports every versions of Swagger/OpenAPI specifications, and also supports LLM function calling schemas of the most LLM providers like {OpenAI, Claude, gemini, and Llama}. For the efficient and accrurate conversion process, `@samchon/openapi` has OpenAPI v3.1 emended specification for intermediate purpose. The LLM function calling schema conversion starts from the OpenAPI v3.1 emended specification.
+It supports every versions of Swagger/OpenAPI specifications, and also supports LLM function calling schemas of the most LLM vendors like {OpenAI, Claude, gemini, and Llama}. For the efficient and accrurate conversion process, `@samchon/openapi` has OpenAPI v3.1 emended specification for intermediate purpose. The LLM function calling schema conversion starts from the OpenAPI v3.1 emended specification.
 
 Therefore, the first thing what should do is composing the OpenAPI v3.1 emended specified document by the calling the `OpenApi.convert()` function. And then, compose the `IHttpLlmApplication` typed structure by calling the `HttpLlm.application()` function with target model and emended OpenAPI document.
 
@@ -113,11 +113,11 @@ const main = async (): Promise<void> => {
   });
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    vendor: {
       api: new OpenAI({
         apiKey: "YOUR_OPENAI_API_KEY",
       }),
+      model: "gpt-4o-mini",
     },
     controllers: [
       {
@@ -187,9 +187,9 @@ export const ShoppingChatApplication = (
 
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    vendor: {
       api: props.api,
+      model: "gpt-4o-mini",
     },
     controllers: [
       {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@agentica/station",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Agentic AI library specialized in LLM Function Calling",
   "engines": {
     "pnpm": ">=8"

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -51,11 +51,11 @@ const main = async (): Promise<void> => {
   // CREATE AI AGENT
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    vendor: {
       api: new OpenAI({
         apiKey: "YOUR_OPENAI_API_KEY",
       }),
+      model: "gpt-4o-mini",
     },
     controllers: [
       {
@@ -193,11 +193,11 @@ const main = async (): Promise<void> => {
   // CREATE AI AGENT
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    vendor: {
       api: new OpenAI({
         apiKey: "YOUR_OPENAI_API_KEY",
       }),
+      model: "gpt-4o-mini",
     },
     controllers: [
       {

--- a/packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts
+++ b/packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts
@@ -20,9 +20,9 @@ export namespace AgenticaBenchmarkPredicator {
     >().functions[0]!;
     const result: OpenAI.ChatCompletion = await agent[
       "props"
-    ].provider.api.chat.completions.create(
+    ].vendor.api.chat.completions.create(
       {
-        model: agent["props"].provider.model,
+        model: agent["props"].vendor.model,
         messages: [
           {
             role: "system",
@@ -52,7 +52,7 @@ export namespace AgenticaBenchmarkPredicator {
         tool_choice: "required",
         parallel_tool_calls: false,
       },
-      agent["props"].provider.options,
+      agent["props"].vendor.options,
     );
     const toolCall: OpenAI.ChatCompletionMessageToolCall | undefined = (
       result.choices[0]?.message.tool_calls ?? []

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,11 +75,11 @@ const main = async (): Promise<void> => {
   // CREATE AN AGENT WITH THE APPLICATION
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    vendor: {
       api: new OpenAI({
         apiKey: "YOUR_OPENAI_API_KEY",
       }),
+      model: "gpt-4o-mini",
     },
     controllers: [
       {
@@ -169,11 +169,11 @@ const main = async (): Promise<void> => {
   });
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    vendor: {
       api: new OpenAI({
         apiKey: "YOUR_OPENAI_API_KEY",
       }),
+      model: "gpt-4o-mini",
     },
     controllers: [
       {
@@ -228,11 +228,11 @@ const main = async (): Promise<void> => {
   });
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
-      model: "gpt-4o-mini",
+    context: {
       api: new OpenAI({
         apiKey: "YOUR_OPENAI_API_KEY",
       }),
+      model: "gpt-4o-mini",
     },
     controllers: [
       {
@@ -356,7 +356,7 @@ export const correctFunctionCall = (p: {
 
 Is LLM function calling perfect? 
 
-The answer is not, and LLM (Large Language Model) providers like OpenAI take a lot of type level mistakes when composing the arguments of the target function to call. Even though an LLM function calling schema has defined an `Array<string>` type, LLM often fills it just by a `string` typed value.
+The answer is not, and LLM (Large Language Model) vendors like OpenAI take a lot of type level mistakes when composing the arguments of the target function to call. Even though an LLM function calling schema has defined an `Array<string>` type, LLM often fills it just by a `string` typed value.
 
 Therefore, when developing an LLM function calling agent, the validation feedback process is essentially required. If LLM takes a type level mistake on arguments composition, the agent must feedback the most detailed validation errors, and let the LLM to retry the function calling referencing the validation errors.
 
@@ -410,7 +410,7 @@ The secret is on the above diagram.
 
 In the OpenAPI specification, there are three versions with different definitions. And even in the same version, there are too much ambiguous and duplicated expressions. To resolve these problems, [`@samchon/openapi`](https://github.com/samchon/openapi) is transforming every OpenAPI documents to v3.1 emended specification. The `@samchon/openapi`'s emended v3.1 specification has removed every ambiguous and duplicated expressions for clarity.
 
-With the v3.1 emended OpenAPI document, `@samchon/openapi` converts it to a migration schema that is near to the function structure. And as the last step, the migration schema will be transformed to a specific LLM provider's function calling schema. LLM function calling schemas are composed like this way.
+With the v3.1 emended OpenAPI document, `@samchon/openapi` converts it to a migration schema that is near to the function structure. And as the last step, the migration schema will be transformed to a specific LLM vendor's function calling schema. LLM function calling schemas are composed like this way.
 
 > **Why do not directly convert, but intermediate?**
 >

--- a/packages/core/src/Agentica.ts
+++ b/packages/core/src/Agentica.ts
@@ -15,8 +15,8 @@ import { IAgenticaOperationCollection } from "./structures/IAgenticaOperationCol
 import { IAgenticaOperationSelection } from "./structures/IAgenticaOperationSelection";
 import { IAgenticaPrompt } from "./structures/IAgenticaPrompt";
 import { IAgenticaProps } from "./structures/IAgenticaProps";
-import { IAgenticaProvider } from "./structures/IAgenticaProvider";
 import { IAgenticaTokenUsage } from "./structures/IAgenticaTokenUsage";
+import { IAgenticaVendor } from "./structures/IAgenticaVendor";
 
 /**
  * Nestia A.I. chatbot agent.
@@ -33,7 +33,7 @@ import { IAgenticaTokenUsage } from "./structures/IAgenticaTokenUsage";
  *
  * - Constructors
  *   - {@link IAgenticaProps}
- *   - {@link IAgenticaProvider}
+ *   - {@link IAgenticaVendor}
  *   - {@link IAgenticaController}
  *   - {@link IAgenticaConfig}
  *   - {@link IAgenticaSystemPrompt}
@@ -146,10 +146,10 @@ export class Agentica<Model extends ILlmSchema.Model> {
   }
 
   /**
-   * Get LLM Provider.
+   * Get LLM vendor.
    */
-  public getProvider(): IAgenticaProvider {
-    return this.props.provider;
+  public getVendor(): IAgenticaVendor {
+    return this.props.vendor;
   }
 
   /**
@@ -225,15 +225,15 @@ export class Agentica<Model extends ILlmSchema.Model> {
           source: kind,
           body: {
             ...body,
-            model: this.props.provider.model,
+            model: this.props.vendor.model,
           },
-          options: this.props.provider.options,
+          options: this.props.vendor.options,
         };
         await dispatch(event);
 
         // completion
         const completion: OpenAI.ChatCompletion =
-          await this.props.provider.api.chat.completions.create(
+          await this.props.vendor.api.chat.completions.create(
             event.body,
             event.options,
           );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export * from "./structures/IAgenticaOperationCollection";
 export * from "./structures/IAgenticaOperationSelection";
 export * from "./structures/IAgenticaPrompt";
 export * from "./structures/IAgenticaProps";
-export * from "./structures/IAgenticaProvider";
+export * from "./structures/IAgenticaVendor";
 export * from "./structures/IAgenticaSystemPrompt";
 export * from "./structures/IAgenticaTokenUsage";
 export * from "./typings/AgenticaSource";

--- a/packages/core/src/structures/IAgenticaContext.ts
+++ b/packages/core/src/structures/IAgenticaContext.ts
@@ -25,7 +25,7 @@ import { IAgenticaPrompt } from "./IAgenticaPrompt";
  *   - {@link ChatGptCancelFunctionAgent}
  *
  * Also, as its name is context, it contains every information that
- * is required to interact with the AI provider like OpenAI. It
+ * is required to interact with the AI vendor like OpenAI. It
  * contains every operations for LLM function calling, and
  * configuration used for the agent construction. And it contains
  * the prompt histories, and facade controller functions for

--- a/packages/core/src/structures/IAgenticaEvent.ts
+++ b/packages/core/src/structures/IAgenticaEvent.ts
@@ -176,7 +176,7 @@ export namespace IAgenticaEvent {
   }
 
   /**
-   * Request event of LLM provider API.
+   * Request event of LLM vendor API.
    */
   export interface IRequest extends IBase<"request"> {
     /**
@@ -196,7 +196,7 @@ export namespace IAgenticaEvent {
   }
 
   /**
-   * Response event of LLM provider API.
+   * Response event of LLM vendor API.
    */
   export interface IResponse extends IBase<"response"> {
     /**
@@ -215,7 +215,7 @@ export namespace IAgenticaEvent {
     options?: OpenAI.RequestOptions | undefined;
 
     /**
-     * Return value from the LLM provider API.
+     * Return value from the LLM vendor API.
      */
     value: OpenAI.ChatCompletion;
   }

--- a/packages/core/src/structures/IAgenticaProps.ts
+++ b/packages/core/src/structures/IAgenticaProps.ts
@@ -4,7 +4,7 @@ import { Primitive } from "typia";
 import { IAgenticaConfig } from "./IAgenticaConfig";
 import { IAgenticaController } from "./IAgenticaController";
 import { IAgenticaPrompt } from "./IAgenticaPrompt";
-import { IAgenticaProvider } from "./IAgenticaProvider";
+import { IAgenticaVendor } from "./IAgenticaVendor";
 
 /**
  * Properties of the Nestia Agent.
@@ -14,7 +14,7 @@ import { IAgenticaProvider } from "./IAgenticaProvider";
  * there're everything to prepare to create a Super A.I. chatbot
  * performing the LLM (Large Language Model) function calling.
  *
- * At first, you have to specify the LLM service {@link provider} like
+ * At first, you have to specify the LLM service {@link vendor} like
  * OpenAI with its API key and client API. And then, you have to define
  * the {@link controllers} serving the functions to call. The controllers
  * are separated by two protocols; HTTP API and TypeScript class. At last,
@@ -34,9 +34,9 @@ export interface IAgenticaProps<Model extends ILlmSchema.Model> {
   model: Model;
 
   /**
-   * LLM service provider.
+   * LLM service vendor.
    */
-  provider: IAgenticaProvider;
+  vendor: IAgenticaVendor;
 
   /**
    * Controllers serving functions to call.

--- a/packages/core/src/structures/IAgenticaTokenUsage.ts
+++ b/packages/core/src/structures/IAgenticaTokenUsage.ts
@@ -10,9 +10,9 @@
  * information, and does not contain any price or cost information. It is
  * because the price or cost can be changed by below reasons.
  *
- * - Type of {@link IAgenticaProps.provider LLM provider}
- * - {@link IAgenticaProvider.model} in the LLM provider.
- * - Just by a policy change of the LLM provider company.
+ * - Type of {@link IAgenticaProps.vendor LLM vendor}
+ * - {@link IAgenticaVendor.model} in the LLM vendor.
+ * - Just by a policy change of the LLM vendor company.
  *
  * @author Samchon
  */

--- a/packages/core/src/structures/IAgenticaVendor.ts
+++ b/packages/core/src/structures/IAgenticaVendor.ts
@@ -1,25 +1,25 @@
 import OpenAI from "openai";
 
 /**
- * LLM Provider for Nestia Chat.
+ * LLM service vendor for Nestia Chat.
  *
- * `IAgenticaProvider` is a type represents an LLM
- * (Large Language Model) provider of the {@link Agentica}.
+ * `IAgenticaVendor` is a type represents an LLM
+ * (Large Language Model) vendor of the {@link Agentica}.
  *
  * Currently, {@link Agentica} supports OpenAI SDK. However, it does
  * not mean that you can use only OpenAI's GPT model in the
  * {@link Agentica}. The OpenAI SDK is just a connection tool to the
- * LLM provider's API, and you can use other LLM providers by configuring
+ * LLM vendor's API, and you can use other LLM vendors by configuring
  * its `baseURL` and API key.
  *
- * Therefore, if you want to use another LLM provider like Claude or
+ * Therefore, if you want to use another LLM vendor like Claude or
  * Gemini, please configure the `baseURL` to the {@link api}, and
  * set {@link IAgenticaController}'s schema model as "cluade" or
  * "gemini".
  *
  * @author Samchon
  */
-export interface IAgenticaProvider {
+export interface IAgenticaVendor {
   /**
    * OpenAI API instance.
    */

--- a/test/src/cli.ts
+++ b/test/src/cli.ts
@@ -70,7 +70,7 @@ const main = async (): Promise<void> => {
   // COMPOSE CHAT AGENT
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
+    vendor: {
       api: new OpenAI({
         apiKey: TestGlobal.env.CHATGPT_API_KEY,
         baseURL: TestGlobal.env.CHATGPT_BASE_URL,

--- a/test/src/features/test_base_event.ts
+++ b/test/src/features/test_base_event.ts
@@ -14,7 +14,7 @@ export async function test_base_event(): Promise<void | false> {
   // initialize agent
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
+    vendor: {
       model: "gpt-4o-mini",
       api: new OpenAI({
         apiKey: TestGlobal.env.CHATGPT_API_KEY,

--- a/test/src/features/test_base_websocket.ts
+++ b/test/src/features/test_base_websocket.ts
@@ -24,7 +24,7 @@ export const test_base_websocket = async (): Promise<void | false> => {
   await server.open(port, async (acceptor) => {
     const agent: Agentica<"chatgpt"> = new Agentica({
       model: "chatgpt",
-      provider: {
+      vendor: {
         model: "gpt-4o-mini",
         api: new OpenAI({
           apiKey: TestGlobal.env.CHATGPT_API_KEY,

--- a/test/src/features/test_base_work.ts
+++ b/test/src/features/test_base_work.ts
@@ -8,7 +8,7 @@ export async function test_base_work(): Promise<void | false> {
 
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
+    vendor: {
       model: "gpt-4o-mini",
       api: new OpenAI({
         apiKey: TestGlobal.env.CHATGPT_API_KEY,

--- a/test/src/features/test_benchmark_call.ts
+++ b/test/src/features/test_benchmark_call.ts
@@ -35,7 +35,7 @@ export const test_benchmark_call = async (): Promise<void | false> => {
   // CREATE AI AGENT
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
+    vendor: {
       model: "gpt-4o-mini",
       api: new OpenAI({
         apiKey: process.env.CHATGPT_API_KEY,

--- a/test/src/features/test_benchmark_predicator.ts
+++ b/test/src/features/test_benchmark_predicator.ts
@@ -10,7 +10,7 @@ export const test_benchmark_predicator = async (): Promise<void> => {
   //----
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
+    vendor: {
       model: "gpt-4o-mini",
       api: null!,
     },

--- a/test/src/features/test_benchmark_predicator_simple_allof.ts
+++ b/test/src/features/test_benchmark_predicator_simple_allof.ts
@@ -10,7 +10,7 @@ export const test_benchmark_predicator_simple_allof =
     //----
     const agent: Agentica<"chatgpt"> = new Agentica({
       model: "chatgpt",
-      provider: {
+      vendor: {
         model: "gpt-4o-mini",
         api: null!,
       },

--- a/test/src/features/test_benchmark_select.ts
+++ b/test/src/features/test_benchmark_select.ts
@@ -12,7 +12,7 @@ export const test_benchmark_select = async (): Promise<void | false> => {
 
   const agent: Agentica<"chatgpt"> = new Agentica({
     model: "chatgpt",
-    provider: {
+    vendor: {
       model: "gpt-4o-mini",
       api: new OpenAI({
         apiKey: process.env.CHATGPT_API_KEY,


### PR DESCRIPTION
To avoid the same word confusing between LLM provider and function providing, I've separated them to vendor and controller.

---------------

This pull request includes several changes across multiple files to update terminology from "provider" to "vendor" and to update the version number in `package.json`. The most important changes are summarized below:

Terminology Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20): Changed `provider` to `vendor` in the `Agentica` initialization.
* [`articles/new-backend-development-paradigm-in-the-new-ai-era.md`](diffhunk://#diff-c353bd6ccba7821dbb937f8c53d8cd1197819fb5a10edd09c682ece233a2b71dL62-R62): Changed `provider` to `vendor` in multiple instances to reflect the new terminology. [[1]](diffhunk://#diff-c353bd6ccba7821dbb937f8c53d8cd1197819fb5a10edd09c682ece233a2b71dL62-R62) [[2]](diffhunk://#diff-c353bd6ccba7821dbb937f8c53d8cd1197819fb5a10edd09c682ece233a2b71dL116-R120) [[3]](diffhunk://#diff-c353bd6ccba7821dbb937f8c53d8cd1197819fb5a10edd09c682ece233a2b71dL190-R192)
* [`packages/benchmark/README.md`](diffhunk://#diff-4bd61f7eef3b5adc4b0047d5b7303ac0f6c6008d6058d68e8bb180155ec376b3L54-R58): Updated `provider` to `vendor` in the `Agentica` initialization. [[1]](diffhunk://#diff-4bd61f7eef3b5adc4b0047d5b7303ac0f6c6008d6058d68e8bb180155ec376b3L54-R58) [[2]](diffhunk://#diff-4bd61f7eef3b5adc4b0047d5b7303ac0f6c6008d6058d68e8bb180155ec376b3L196-R200)
* [`packages/core/README.md`](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L78-R82): Updated `provider` to `vendor` in the `Agentica` initialization and other references. [[1]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L78-R82) [[2]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L172-R176) [[3]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L231-R235) [[4]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L359-R359) [[5]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L413-R413)
* [`packages/core/src/Agentica.ts`](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L18-R19): Replaced `IAgenticaProvider` with `IAgenticaVendor` and updated relevant methods and properties. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L18-R19) [[2]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L36-R36) [[3]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L149-R152) [[4]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L228-R236)
* [`packages/core/src/index.ts`](diffhunk://#diff-9a4ceebe7c6f86856371906c3f061d3b56b7457022b05179884a113e7ced67e8L12-R12): Updated export from `IAgenticaProvider` to `IAgenticaVendor`.
* [`packages/core/src/structures/IAgenticaContext.ts`](diffhunk://#diff-296ff415216c8bd257d000648ec51d57d628076671374a53c1d56abb87e81f10L28-R28): Updated references from `provider` to `vendor`.
* [`packages/core/src/structures/IAgenticaEvent.ts`](diffhunk://#diff-39962af9724cf1f2b4b5f02606d326a161c51dc2b6af632861569f111aba7460L179-R179): Updated references from `provider` to `vendor`. [[1]](diffhunk://#diff-39962af9724cf1f2b4b5f02606d326a161c51dc2b6af632861569f111aba7460L179-R179) [[2]](diffhunk://#diff-39962af9724cf1f2b4b5f02606d326a161c51dc2b6af632861569f111aba7460L199-R199) [[3]](diffhunk://#diff-39962af9724cf1f2b4b5f02606d326a161c51dc2b6af632861569f111aba7460L218-R218)
* [`packages/core/src/structures/IAgenticaProps.ts`](diffhunk://#diff-b153121558c9ae303b601ce499c06b749df2cf9a0de205a15de9a5bb097f5977L7-R7): Replaced `IAgenticaProvider` with `IAgenticaVendor` and updated relevant properties. [[1]](diffhunk://#diff-b153121558c9ae303b601ce499c06b749df2cf9a0de205a15de9a5bb097f5977L7-R7) [[2]](diffhunk://#diff-b153121558c9ae303b601ce499c06b749df2cf9a0de205a15de9a5bb097f5977L17-R17) [[3]](diffhunk://#diff-b153121558c9ae303b601ce499c06b749df2cf9a0de205a15de9a5bb097f5977L37-R39)
* [`packages/core/src/structures/IAgenticaTokenUsage.ts`](diffhunk://#diff-099346ce94c33aa3619deb1298d06bd45ba60b4c1aade4f0c3be320f56154c63L13-R15): Updated references from `provider` to `vendor`.
* [`packages/core/src/structures/IAgenticaVendor.ts`](diffhunk://#diff-0c7462e3ea2b2448c16762e1c0577e2f28bd236d091f48a8846590fb62c791d7L4-R22): Renamed from `IAgenticaProvider.ts` and updated content to reflect the new terminology.
* [`test/src/cli.ts`](diffhunk://#diff-702ef007af152086625566f4fd52a03a204d4380d9f53e1dcd123e9d3c17f798L73-R73): Updated `provider` to `vendor` in the `Agentica` initialization.
* [`test/src/features/test_base_event.ts`](diffhunk://#diff-27e7e5427e3d38845c4723647369987ddb20c284789d28e25424d00ba3af4df1L17-R17): Updated `provider` to `vendor` in the `Agentica` initialization.
* [`test/src/features/test_base_websocket.ts`](diffhunk://#diff-4fb8557f645079e58758926383fe3a8142eb77051cdd9705ed335e0138d02590L27-R27): Updated `provider` to `vendor` in the `Agentica` initialization.

Version Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version number from `0.9.0` to `0.10.0`.