### PR TITLE
Utilize `IHttpLlmFunction.validate()` function

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -179,7 +179,7 @@ const main = async (): Promise<void> => {
       {
         protocol: "class",
         name: "vectorStore",
-        application: typia.llm.applicationOfValidate<
+        application: typia.llm.application<
           BbsArticleService,
           "chatgpt"
         >(),
@@ -238,7 +238,7 @@ const main = async (): Promise<void> => {
       {
         protocol: "class",
         name: "vectorStore",
-        application: typia.llm.applicationOfValidate<
+        application: typia.llm.application<
           OpenAIVectorStoreAgent,
           "chatgpt"
         >(),
@@ -320,15 +320,15 @@ Such LLM (Large Language Model) function calling strategy separating `selector`,
 ### Validation Feedback
 ```typescript
 import { FunctionCall } from "pseudo";
-import { ILlmFunctionOfValidate, IValidation } from "typia";
+import { ILlmFunction, IValidation } from "typia";
 
 export const correctFunctionCall = (p: {
   call: FunctionCall;
-  functions: Array<ILlmFunctionOfValidate<"chatgpt">>;
+  functions: Array<ILlmFunction<"chatgpt">>;
   retry: (reason: string, errors?: IValidation.IError[]) => Promise<unknown>;
 }): Promise<unknown> => {
   // FIND FUNCTION
-  const func: ILlmFunctionOfValidate<"chatgpt"> | undefined =
+  const func: ILlmFunction<"chatgpt"> | undefined =
     p.functions.find((f) => f.name === p.call.name);
   if (func === undefined) {
     // never happened in my experience
@@ -360,7 +360,7 @@ The answer is not, and LLM (Large Language Model) vendors like OpenAI take a lot
 
 Therefore, when developing an LLM function calling agent, the validation feedback process is essentially required. If LLM takes a type level mistake on arguments composition, the agent must feedback the most detailed validation errors, and let the LLM to retry the function calling referencing the validation errors.
 
-About the validation feedback, `@agentica/core` is utilizing [`typia.validate<T>()`](https://typia.io/docs/validators/validate) and [`typia.llm.applicationOfValidate<Class, Model>()`](https://typia.io/docs/llm/application/#applicationofvalidate) functions. They construct validation logic by analyzing TypeScript source codes and types in the compilation level, so that detailed and accurate than any other validators like below.
+About the validation feedback, `@agentica/core` is utilizing [`typia.validate<T>()`](https://typia.io/docs/validators/validate) and [`typia.llm.application<Class, Model>()`](https://typia.io/docs/llm/application/#application) functions. They construct validation logic by analyzing TypeScript source codes and types in the compilation level, so that detailed and accurate than any other validators like below.
 
 Such validation feedback strategy and combination with `typia` runtime validator, `@agentica/core` has achieved the most ideal LLM function calling. In my experience, when using OpenAI's `gpt-4o-mini` model, it tends to construct invalid function calling arguments at the first trial about 50% of the time. By the way, if correct it through validation feedback with `typia`, success rate soars to 99%. And I've never had a failure when trying validation feedback twice.
 
@@ -404,7 +404,7 @@ flowchart
   end
 ```
 
-`@agentica/core` obtains LLM function calling schemas from both Swagger/OpenAPI documents and TypeScript class types. The TypeScript class type can be converted to LLM function calling schema by [`typia.llm.applicationOfValidate<Class, Model>()`](https://typia.io/docs/llm/application#applicationofvalidate) function. Then how about OpenAPI document? How Swagger document can be LLM function calling schema.
+`@agentica/core` obtains LLM function calling schemas from both Swagger/OpenAPI documents and TypeScript class types. The TypeScript class type can be converted to LLM function calling schema by [`typia.llm.application<Class, Model>()`](https://typia.io/docs/llm/application#application) function. Then how about OpenAPI document? How Swagger document can be LLM function calling schema.
 
 The secret is on the above diagram. 
 

--- a/packages/core/src/chatgpt/ChatGptCallFunctionAgent.ts
+++ b/packages/core/src/chatgpt/ChatGptCallFunctionAgent.ts
@@ -174,6 +174,22 @@ export namespace ChatGptCallFunctionAgent {
       //----
       // HTTP PROTOCOL
       //----
+      // NESTED VALIDATOR
+      const check: IValidation<unknown> = call.operation.function.validate(
+        call.arguments,
+      );
+      if (
+        check.success === false &&
+        retry++ < (ctx.config?.retry ?? AgenticaConstant.RETRY)
+      ) {
+        const trial: IAgenticaPrompt.IExecute<Model> | null = await correct(
+          ctx,
+          call,
+          retry,
+          check.errors,
+        );
+        if (trial !== null) return trial;
+      }
       try {
         // CALL HTTP API
         const response: IHttpResponse = call.operation.controller.execute

--- a/packages/core/src/structures/IAgenticaController.ts
+++ b/packages/core/src/structures/IAgenticaController.ts
@@ -3,9 +3,10 @@ import {
   IHttpLlmApplication,
   IHttpLlmFunction,
   IHttpResponse,
+  ILlmApplication,
+  ILlmFunction,
   ILlmSchema,
 } from "@samchon/openapi";
-import { ILlmApplicationOfValidate, ILlmFunctionOfValidate } from "typia";
 
 /**
  * Controller of the Nestia Agent.
@@ -85,7 +86,7 @@ export namespace IAgenticaController {
    * - https://typia.io/docs/llm/application
    */
   export interface IClass<Model extends ILlmSchema.Model>
-    extends IBase<"class", ILlmApplicationOfValidate<Model>> {
+    extends IBase<"class", ILlmApplication<Model>> {
     /**
      * Executor of the class function.
      *
@@ -99,12 +100,12 @@ export namespace IAgenticaController {
           /**
            * Target application schema.
            */
-          application: ILlmApplicationOfValidate<Model>;
+          application: ILlmApplication<Model>;
 
           /**
            * Target function schema.
            */
-          function: ILlmFunctionOfValidate<Model>;
+          function: ILlmFunction<Model>;
 
           /**
            * Arguments of the function calling.

--- a/packages/core/src/structures/IAgenticaOperation.ts
+++ b/packages/core/src/structures/IAgenticaOperation.ts
@@ -1,5 +1,4 @@
-import { IHttpLlmFunction, ILlmSchema } from "@samchon/openapi";
-import { ILlmFunctionOfValidate } from "typia";
+import { IHttpLlmFunction, ILlmFunction, ILlmSchema } from "@samchon/openapi";
 
 import { IAgenticaController } from "./IAgenticaController";
 
@@ -37,7 +36,7 @@ export namespace IAgenticaOperation {
   export type IClass<Model extends ILlmSchema.Model> = IBase<
     "class",
     IAgenticaController.IClass<Model>,
-    ILlmFunctionOfValidate<Model>
+    ILlmFunction<Model>
   >;
 
   interface IBase<Protocol, Application, Function> {

--- a/packages/core/src/structures/IAgenticaOperationSelection.ts
+++ b/packages/core/src/structures/IAgenticaOperationSelection.ts
@@ -1,5 +1,4 @@
-import { IHttpLlmFunction, ILlmSchema } from "@samchon/openapi";
-import { ILlmFunctionOfValidate } from "typia";
+import { IHttpLlmFunction, ILlmFunction, ILlmSchema } from "@samchon/openapi";
 
 import { IAgenticaController } from "./IAgenticaController";
 
@@ -29,7 +28,7 @@ export namespace IAgenticaOperationSelection {
   export type IClass<Model extends ILlmSchema.Model> = IBase<
     "class",
     IAgenticaController.IClass<Model>,
-    ILlmFunctionOfValidate<Model>
+    ILlmFunction<Model>
   >;
 
   interface IBase<Protocol, Controller, Function> {

--- a/packages/core/src/structures/IAgenticaPrompt.ts
+++ b/packages/core/src/structures/IAgenticaPrompt.ts
@@ -1,5 +1,9 @@
-import { IHttpLlmFunction, IHttpResponse, ILlmSchema } from "@samchon/openapi";
-import { ILlmFunctionOfValidate } from "typia";
+import {
+  IHttpLlmFunction,
+  IHttpResponse,
+  ILlmFunction,
+  ILlmSchema,
+} from "@samchon/openapi";
 
 import { IAgenticaController } from "./IAgenticaController";
 import { IAgenticaOperationSelection } from "./IAgenticaOperationSelection";
@@ -81,7 +85,7 @@ export namespace IAgenticaPrompt {
     export type IClass<Model extends ILlmSchema.Model> = IBase<
       "class",
       IAgenticaController.IClass<Model>,
-      ILlmFunctionOfValidate<Model>,
+      ILlmFunction<Model>,
       any
     >;
     interface IBase<Protocol, Controller, Function, Value> {


### PR DESCRIPTION
This pull request focuses on simplifying the codebase by replacing the `ILlmFunctionOfValidate` and `ILlmApplicationOfValidate` types with `ILlmFunction` and `ILlmApplication` respectively across multiple files in the `packages/core` directory. The changes aim to streamline the type definitions and improve code readability.

The most important changes include:

### Type Replacement:

* [`packages/core/README.md`](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L182-R182): Replaced `ILlmFunctionOfValidate` with `ILlmFunction` and `ILlmApplicationOfValidate` with `ILlmApplication` in various code examples and documentation references. [[1]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L182-R182) [[2]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L241-R241) [[3]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L323-R331) [[4]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L363-R363) [[5]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L407-R407)
* [`packages/core/src/structures/IAgenticaController.ts`](diffhunk://#diff-940724b541af593040f1d429094d8ae09e1f42051e975c0163222a409aa42a1cR6-L8): Updated interfaces to use `ILlmFunction` and `ILlmApplication` instead of their `OfValidate` counterparts. [[1]](diffhunk://#diff-940724b541af593040f1d429094d8ae09e1f42051e975c0163222a409aa42a1cR6-L8) [[2]](diffhunk://#diff-940724b541af593040f1d429094d8ae09e1f42051e975c0163222a409aa42a1cL88-R89) [[3]](diffhunk://#diff-940724b541af593040f1d429094d8ae09e1f42051e975c0163222a409aa42a1cL102-R108)
* [`packages/core/src/structures/IAgenticaOperation.ts`](diffhunk://#diff-faf1f006ea6371e569bea76b2e82334cfd1c8a59b8d410c0c99e0562bab3559bL1-R1): Modified the type definitions to use `ILlmFunction` instead of `ILlmFunctionOfValidate`. [[1]](diffhunk://#diff-faf1f006ea6371e569bea76b2e82334cfd1c8a59b8d410c0c99e0562bab3559bL1-R1) [[2]](diffhunk://#diff-faf1f006ea6371e569bea76b2e82334cfd1c8a59b8d410c0c99e0562bab3559bL40-R39)
* [`packages/core/src/structures/IAgenticaOperationSelection.ts`](diffhunk://#diff-38dadac50041765868313f6a9d7bd9bfa19624a5bb6b46fcbcddc01bcbc47383L1-R1): Changed type references from `ILlmFunctionOfValidate` to `ILlmFunction`. [[1]](diffhunk://#diff-38dadac50041765868313f6a9d7bd9bfa19624a5bb6b46fcbcddc01bcbc47383L1-R1) [[2]](diffhunk://#diff-38dadac50041765868313f6a9d7bd9bfa19624a5bb6b46fcbcddc01bcbc47383L32-R31)
* [`packages/core/src/structures/IAgenticaPrompt.ts`](diffhunk://#diff-0be4fec906bc5c9412f022477fada6e7c7adb914001dc11b15ba29796065745dL1-R6): Replaced `ILlmFunctionOfValidate` with `ILlmFunction` in type definitions. [[1]](diffhunk://#diff-0be4fec906bc5c9412f022477fada6e7c7adb914001dc11b15ba29796065745dL1-R6) [[2]](diffhunk://#diff-0be4fec906bc5c9412f022477fada6e7c7adb914001dc11b15ba29796065745dL84-R88)

### New Validation Logic:

* [`packages/core/src/chatgpt/ChatGptCallFunctionAgent.ts`](diffhunk://#diff-6b0fd1c4ca04075d7c1dbb7137babf83d0a9f105ec30afd3c459cd6a7b3007e1R177-R192): Added nested validation logic to handle function call retries based on validation errors.