### PR TITLE
fix: Change the document's light theme background color to white

### DIFF
--- a/website/app/layout.jsx
+++ b/website/app/layout.jsx
@@ -34,7 +34,7 @@ export default async function RootLayout(props) {
       <Head
         backgroundColor={{
           dark: "rgb(9, 15, 27)",
-          light: "rgb(254, 252, 232)",
+          light: "rgb(250, 250, 250)",
         }}
         // color={{
         //   hue: { dark: 120, light: 0 },


### PR DESCRIPTION
Yellow to white(254,252,232 -> 250,250,250)

before:
![스크린샷 2025-03-10 오전 11 11 26](https://github.com/user-attachments/assets/57926931-f039-4f93-84e1-779103e11478)


after:
![스크린샷 2025-03-10 오전 11 11 36](https://github.com/user-attachments/assets/43ec62d1-8677-49ca-bb5b-c7e2b7ba1c4b)


maybe you follow [generated code](https://nextra.site/docs/blog-theme/start#:~:text=%3CHead%20backgroundColor%3D%7B%7B%20dark%3A%20%27%230f172a%27%2C%20light%3A%20%27%23fefce8%27%20%7D%7D%20/%3E), but nextra page use [250,250,250](https://nextra.site/docs/blog-theme/start)

