### PR TITLE
Fix websocket problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@agentica/station",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Agentic AI library specialized in LLM Function Calling",
   "engines": {
     "pnpm": ">=8"

--- a/packages/core/src/context/internal/AgenticaTokenUsageAggregator.ts
+++ b/packages/core/src/context/internal/AgenticaTokenUsageAggregator.ts
@@ -1,11 +1,11 @@
 import { CompletionUsage } from "openai/resources";
-import { Primitive } from "typia";
 
+import { IAgenticaTokenUsageJson } from "../../json/IAgenticaTokenUsageJson";
 import { AgenticaTokenUsage } from "../AgenticaTokenUsage";
 
 export namespace AgenticaTokenUsageAggregator {
   export const aggregate = (props: {
-    kind: Exclude<keyof Primitive<AgenticaTokenUsage>, "aggregate">;
+    kind: Exclude<keyof IAgenticaTokenUsageJson, "aggregate">;
     completionUsage: CompletionUsage;
     usage: AgenticaTokenUsage;
   }): void => {

--- a/packages/rpc/src/AgenticaRpcService.ts
+++ b/packages/rpc/src/AgenticaRpcService.ts
@@ -92,12 +92,8 @@ export class AgenticaRpcService<Model extends ILlmSchema.Model>
   /**
    * @inheritDoc
    */
-  public async getControllers(): Promise<
-    Primitive<IAgenticaController<Model>>[]
-  > {
-    return this.props.agent.getControllers() satisfies ReadonlyArray<
-      IAgenticaController<Model>
-    > as Primitive<IAgenticaController<Model>>[];
+  public async getControllers(): Promise<IAgenticaController<Model>[]> {
+    return this.props.agent.getControllers() as IAgenticaController<Model>[];
   }
 }
 export namespace AgenticaRpcService {

--- a/packages/rpc/src/IAgenticaRpcListener.ts
+++ b/packages/rpc/src/IAgenticaRpcListener.ts
@@ -1,5 +1,4 @@
 import { IAgenticaEventJson } from "@agentica/core";
-import { Primitive } from "typia";
 
 /**
  * RPC interface of AI agent listener.
@@ -52,18 +51,14 @@ export interface IAgenticaRpcListener {
    *
    * @param evt Event of a description of function execution results
    */
-  describe(
-    evt: Primitive<IAgenticaEventJson.IDescribe> & { text: string },
-  ): Promise<void>;
+  describe(evt: IAgenticaEventJson.IDescribe): Promise<void>;
 
   /**
    * Text conversation message.
    *
    * @param evt Event of a text conversation message
    */
-  text(
-    evt: Primitive<IAgenticaEventJson.IText> & { text: string },
-  ): Promise<void>;
+  text(evt: IAgenticaEventJson.IText): Promise<void>;
 
   /**
    * Initialize the AI agent.
@@ -82,7 +77,7 @@ export interface IAgenticaRpcListener {
    *
    * @param evt Event of selecting a function to call
    */
-  select?(evt: Primitive<IAgenticaEventJson.ISelect>): Promise<void>;
+  select?(evt: IAgenticaEventJson.ISelect): Promise<void>;
 
   /**
    * Cancel a function to call.
@@ -91,7 +86,7 @@ export interface IAgenticaRpcListener {
    *
    * @param evt Event of canceling a function to call
    */
-  cancel?(evt: Primitive<IAgenticaEventJson.ICancel>): Promise<void>;
+  cancel?(evt: IAgenticaEventJson.ICancel): Promise<void>;
 
   /**
    * Call a function.
@@ -110,9 +105,7 @@ export interface IAgenticaRpcListener {
    * @param evt Event of a function calling
    * @return New arguments if you want to modify, otherwise null or undefined
    */
-  call?(
-    evt: Primitive<IAgenticaEventJson.ICall>,
-  ): Promise<object | null | undefined>;
+  call?(evt: IAgenticaEventJson.ICall): Promise<object | null | undefined>;
 
   /**
    * Executition of a function.

--- a/packages/rpc/src/IAgenticaRpcService.ts
+++ b/packages/rpc/src/IAgenticaRpcService.ts
@@ -1,6 +1,5 @@
 import { IAgenticaController } from "@agentica/core";
 import { ILlmSchema } from "@samchon/openapi";
-import { Primitive } from "typia";
 
 /**
  * RPC interface of AI agent service.
@@ -37,5 +36,5 @@ export interface IAgenticaRpcService<Model extends ILlmSchema.Model> {
    * Get controllers, collection of functions that would be
    * called by the AI chatbot.
    */
-  getControllers(): Promise<Primitive<IAgenticaController<Model>[]>>;
+  getControllers(): Promise<IAgenticaController<Model>[]>;
 }

--- a/test/src/features/test_base_websocket.ts
+++ b/test/src/features/test_base_websocket.ts
@@ -34,7 +34,7 @@ export const test_base_websocket = async (): Promise<void | false> => {
     await acceptor.accept(
       new AgenticaRpcService({
         agent,
-        listener: (acceptor as any).getDriver(),
+        listener: acceptor.getDriver(),
       }),
     );
   });
@@ -57,9 +57,7 @@ export const test_base_websocket = async (): Promise<void | false> => {
   });
   await connector.connect(`ws://localhost:${port}`);
 
-  const driver: Driver<IAgenticaRpcService<"chatgpt">> = (
-    connector as any
-  ).getDriver();
+  const driver: Driver<IAgenticaRpcService<"chatgpt">> = connector.getDriver();
   await driver.conversate("What can you do?");
   await connector.close();
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving the codebase by removing the use of the `Primitive` type from `typia` and making minor version updates. The most important changes include modifications to the `AgenticaRpcService`, `IAgenticaRpcListener`, and `IAgenticaRpcService` interfaces, as well as updates to the `test_base_websocket` function.

### Removal of `Primitive` type:

* [`packages/core/src/context/internal/AgenticaTokenUsageAggregator.ts`](diffhunk://#diff-80f3483e6d925b278ef4d4097e99578defcb2f9ccad718d5caebe1a530c46bdbL2-R8): Replaced `Primitive<AgenticaTokenUsage>` with `IAgenticaTokenUsageJson` in the `aggregate` method.
* [`packages/rpc/src/AgenticaRpcService.ts`](diffhunk://#diff-ff117542d38be6a7963841ec4b486914ee24ac26cbc15c123525060a9ea084edL95-R96): Removed `Primitive` type from the return type of `getControllers` method.
* [`packages/rpc/src/IAgenticaRpcListener.ts`](diffhunk://#diff-a7449615bfcbf476b208fba4f3ce6cf07efc4e9021702d06c8c920a71c6ea599L55-R61): Removed `Primitive` type from the parameters of `describe`, `text`, `select`, `cancel`, and `call` methods. [[1]](diffhunk://#diff-a7449615bfcbf476b208fba4f3ce6cf07efc4e9021702d06c8c920a71c6ea599L55-R61) [[2]](diffhunk://#diff-a7449615bfcbf476b208fba4f3ce6cf07efc4e9021702d06c8c920a71c6ea599L85-R80) [[3]](diffhunk://#diff-a7449615bfcbf476b208fba4f3ce6cf07efc4e9021702d06c8c920a71c6ea599L94-R89) [[4]](diffhunk://#diff-a7449615bfcbf476b208fba4f3ce6cf07efc4e9021702d06c8c920a71c6ea599L113-R108)
* [`packages/rpc/src/IAgenticaRpcService.ts`](diffhunk://#diff-2ea1c0ce07c833f0f323ef82a2e9898427b60862add6379095cce6488bcb4595L40-R39): Removed `Primitive` type from the return type of `getControllers` method.

### Minor version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `0.11.0` to `0.11.1`.

### Test improvements:

* [`test/src/features/test_base_websocket.ts`](diffhunk://#diff-4fb8557f645079e58758926383fe3a8142eb77051cdd9705ed335e0138d02590L37-R37): Removed unnecessary type casting to `any` in the `test_base_websocket` function. [[1]](diffhunk://#diff-4fb8557f645079e58758926383fe3a8142eb77051cdd9705ed335e0138d02590L37-R37) [[2]](diffhunk://#diff-4fb8557f645079e58758926383fe3a8142eb77051cdd9705ed335e0138d02590L60-R60)