### PR TITLE
fix: rename waitClose to waitDone and make the criteria for 'done' more re rigorous

### DIFF
--- a/packages/core/src/chatgpt/ChatGptDescribeFunctionAgent.ts
+++ b/packages/core/src/chatgpt/ChatGptDescribeFunctionAgent.ts
@@ -64,7 +64,7 @@ export namespace ChatGptDescribeFunctionAgent {
             continue;
           }
 
-          const { consumer, produce, close, waitClose, done } =
+          const { consumer, produce, close, waitClosed, waitUntilEmpty, done } =
             MPSCUtil.create<string>();
 
           describeContext[choice.index] = {
@@ -72,7 +72,8 @@ export namespace ChatGptDescribeFunctionAgent {
             consumer,
             produce,
             close,
-            waitClose,
+            waitClosed,
+            waitUntilEmpty,
             done,
           };
           produce(choice.delta.content);
@@ -84,7 +85,7 @@ export namespace ChatGptDescribeFunctionAgent {
               done,
               get: () => describeContext[choice.index]?.content ?? "",
               join: async () => {
-                await waitClose();
+                await waitClosed();
                 return describeContext[choice.index]!.content;
               },
             }),

--- a/packages/core/src/events/AgenticaDescribeEvent.ts
+++ b/packages/core/src/events/AgenticaDescribeEvent.ts
@@ -13,6 +13,11 @@ export class AgenticaDescribeEvent<
   public get text(): string {
     return this.get_();
   }
+
+  /**
+   * Check if the join method can return a response immediately.
+   * Returns true if the response is ready to be returned by the join method.
+   */
   public get done(): boolean {
     return this.done_();
   }

--- a/packages/core/src/events/AgenticaTextEvent.ts
+++ b/packages/core/src/events/AgenticaTextEvent.ts
@@ -8,6 +8,11 @@ export class AgenticaTextEvent extends AgenticaEventBase<"text"> {
   public get text(): string {
     return this.get_();
   }
+
+  /**
+   * Check if the join method can return a response immediately.
+   * Returns true if the response is ready to be returned by the join method.
+   */
   public get done(): boolean {
     return this.done_();
   }

--- a/test/src/features/unit/async_queue/test_async_queue_base.ts
+++ b/test/src/features/unit/async_queue/test_async_queue_base.ts
@@ -89,7 +89,7 @@ export async function test_async_queue_base(): Promise<void | false> {
   const waitCloseQueue = new MPSCUtil.AsyncQueue<string>();
 
   // Start waiting for close
-  const closePromise = waitCloseQueue.waitClose();
+  const closePromise = waitCloseQueue.waitClosed();
 
   // Close after delay
   setTimeout(() => {
@@ -144,7 +144,7 @@ export async function test_async_queue_base(): Promise<void | false> {
     consumer: multiConsumer,
     produce: multiProduce,
     close: multiClose,
-    waitClose: multiWaitClose,
+    waitClosed: multiWaitClosed,
   } = MPSCUtil.create<string>();
   const multiReader = multiConsumer.getReader();
 
@@ -174,7 +174,7 @@ export async function test_async_queue_base(): Promise<void | false> {
   }
 
   // Test waitClose functionality
-  const waitClosePromise = multiWaitClose();
+  const waitClosePromise = multiWaitClosed();
   multiClose();
   await waitClosePromise; // Should resolve when closed
 

--- a/test/src/features/unit/mpsc/test_mpsc_base.ts
+++ b/test/src/features/unit/mpsc/test_mpsc_base.ts
@@ -47,18 +47,18 @@ export async function test_mpsc_base(): Promise<void | false> {
     consumer: consumer2,
     produce: produce2,
     close: close2,
-    waitClose,
+    waitClosed,
   } = MPSCUtil.create<string>();
   const reader2 = consumer2.getReader();
   // Produce values first
   produce2("test");
   // Start waiting for close
-  const closePromise = waitClose();
+  const closePromise = waitClosed();
   // Read the value
   const readResult = await reader2.read();
   if (readResult.value !== "test" || readResult.done !== false) {
     throw new Error(
-      `MPSC waitClose test (read) failed: Expected {value: "test", done: false}, got ${JSON.stringify(
+      `MPSC waitClosed test (read) failed: Expected {value: "test", done: false}, got ${JSON.stringify(
         readResult,
       )}`,
     );

--- a/test/src/features/unit/mpsc/test_mpsc_wait_close.ts
+++ b/test/src/features/unit/mpsc/test_mpsc_wait_close.ts
@@ -2,7 +2,7 @@ import { MPSCUtil } from "@agentica/core/src/internal/MPSCUtil";
 
 export async function test_mpsc_wait_close(): Promise<void | false> {
   // Test 1: Basic waitClose functionality
-  const { consumer, produce, close, waitClose } = MPSCUtil.create<string>();
+  const { consumer, produce, close, waitClosed } = MPSCUtil.create<string>();
   const reader = consumer.getReader();
 
   produce("message");
@@ -17,32 +17,32 @@ export async function test_mpsc_wait_close(): Promise<void | false> {
   }
 
   // Call waitClose then execute close
-  const closePromise = waitClose();
+  const closePromise = waitClosed();
   close();
   await closePromise; // Should resolve when closed
 
   const afterClose = await reader.read();
   if (afterClose.done !== true) {
     throw new Error(
-      `waitClose completion test failed: Expected {done: true}, received ${JSON.stringify(
+      `waitClosed completion test failed: Expected {done: true}, received ${JSON.stringify(
         afterClose,
       )}`,
     );
   }
 
   // Test 2: Call waitClose on already closed queue
-  const { close: close2, waitClose: waitClose2 } = MPSCUtil.create<number>();
+  const { close: close2, waitClosed: waitClosed2 } = MPSCUtil.create<number>();
 
   close2(); // Close first
-  const alreadyClosedPromise = waitClose2();
+  const alreadyClosedPromise = waitClosed2();
   // Should resolve immediately since already closed
   await alreadyClosedPromise;
 
   // Test 3: Multiple waitClose calls
-  const { close: close3, waitClose: waitClose3 } = MPSCUtil.create<number>();
+  const { close: close3, waitClosed: waitClosed3 } = MPSCUtil.create<number>();
 
   // Create multiple waitClose promises
-  const waitPromises = [waitClose3(), waitClose3(), waitClose3()];
+  const waitPromises = [waitClosed3(), waitClosed3(), waitClosed3()];
 
   // All promises should resolve
   close3();
@@ -53,12 +53,12 @@ export async function test_mpsc_wait_close(): Promise<void | false> {
     consumer: consumer4,
     produce: produce4,
     close: close4,
-    waitClose: waitClose4,
+    waitClosed: waitClosed4,
   } = MPSCUtil.create<string>();
   const reader4 = consumer4.getReader();
 
   // Call waitClose
-  const waitPromise4 = waitClose4();
+  const waitPromise4 = waitClosed4();
 
   // Check if value production and consumption still work
   produce4("first");
@@ -89,7 +89,7 @@ export async function test_mpsc_wait_close(): Promise<void | false> {
   const afterClose4 = await reader4.read();
   if (afterClose4.done !== true) {
     throw new Error(
-      `waitClose blocking completion test failed: Expected {done: true}, received ${JSON.stringify(
+      `waitClosed blocking completion test failed: Expected {done: true}, received ${JSON.stringify(
         afterClose4,
       )}`,
     );
@@ -100,14 +100,14 @@ export async function test_mpsc_wait_close(): Promise<void | false> {
     consumer: consumer5,
     produce: produce5,
     close: close5,
-    waitClose: waitClose5,
+    waitClosed: waitClosed5,
   } = MPSCUtil.create<number>();
   const reader5 = consumer5.getReader();
 
   produce5(100);
 
   // Call waitClose
-  const waitPromise5 = waitClose5();
+  const waitPromise5 = waitClosed5();
 
   // Perform async close
   setTimeout(() => {


### PR DESCRIPTION
Previously, done and waitClose only checked whether the writer was closed.
As a result, waitClose could be triggered even when the reader was not closed.

I have made modifications accordingly, but I have one question:
Would it be better to separate the closing state of the reader and the writer in this case?