### PR TITLE
docs: add copy component for code 

### DIFF
--- a/website/content/docs/concepts/function-calling.mdx
+++ b/website/content/docs/concepts/function-calling.mdx
@@ -47,7 +47,7 @@ Also, when converting Swagger/OpenAPI document to LLM function calling schemas, 
 
 
 ## Validation Feedback
-```typescript filename="validation-feedback-concept.ts" showLineNumbers
+```typescript filename="validation-feedback-concept.ts" showLineNumbers copy
 import { FunctionCall } from "pseudo";
 import { ILlmFunction, IValidation } from "typia";
 

--- a/website/content/docs/plugins/benchmark.mdx
+++ b/website/content/docs/plugins/benchmark.mdx
@@ -37,7 +37,7 @@ In actually, below shopping mall backend also has incrased its AX (Agent Experie
   <code>IAgenticaSelectBenchmarkEvent</code>,
 ]}>
   <Tabs.Tab>
-```typescript filename="test/benchmark/select.ts" showLineNumbers
+```typescript filename="test/benchmark/select.ts" showLineNumbers copy
 import { 
   AgenticaSelectBenchmark,
   IAgenticaSelectBenchmarkScenario
@@ -60,7 +60,7 @@ await archiveReport(docs);
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="test/benchmark/select.ts" showLineNumbers
+```typescript filename="test/benchmark/select.ts" showLineNumbers copy
 import { 
   AgenticaSelectBenchmark,
   IAgenticaSelectBenchmarkScenario
@@ -203,7 +203,7 @@ main().catch(console.error);
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@agentica/benchmark/AgenticaSelectBenchmark" showLineNumbers
+```typescript filename="@agentica/benchmark/AgenticaSelectBenchmark" showLineNumbers copy
 /**
  * LLM function calling selection benchmark.
  *
@@ -327,7 +327,7 @@ export namespace AgenticaSelectBenchmark {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@agentia/benchmark/IAgenticaSelectBenchmarkEvent" showLineNumbers
+```typescript filename="@agentia/benchmark/IAgenticaSelectBenchmarkEvent" showLineNumbers copy
 /**
  * Event of LLM function selection benchmark.
  *
@@ -464,7 +464,7 @@ After the benchmark, you can get its report by calling the `AgenticaSelectBenchm
   ]}
   selectedIndex={1}>
   <Tabs.Tab>
-```typescript filename="@agentica/benchmark/IAgenticaSelectBenchmarkScenario" showLineNumbers
+```typescript filename="@agentica/benchmark/IAgenticaSelectBenchmarkScenario" showLineNumbers copy
 /**
  * Scenario of function selection.
  *
@@ -507,7 +507,7 @@ export interface IAgenticaSelectBenchmarkScenario<
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@agentica/benchmark/IAgenticaBenchmarkExpected" showLineNumbers
+```typescript filename="@agentica/benchmark/IAgenticaBenchmarkExpected" showLineNumbers copy
 /**
  * Expected operation determinant.
  *

--- a/website/content/docs/plugins/pg-vector-selector.mdx
+++ b/website/content/docs/plugins/pg-vector-selector.mdx
@@ -9,7 +9,7 @@ In the existing Agentica, the Selector could take 1 to 2 seconds, but this libra
 
 ## Installation
 
-```bash
+```bash copy
 npm install @agentica/pg-vector-selector
 ```
 
@@ -17,7 +17,7 @@ npm install @agentica/pg-vector-selector
 
 Just replace the existing `executor.select` with the `selectorExecute` function.
 
-```typescript
+```typescript copy
 import { Agentica } from "@agentica/core";
 import { AgenticaPgVectorSelector } from "@agentica/pg-vector-selector";
 
@@ -65,7 +65,7 @@ Connector-Hive: https://github.com/wrtnlabs/connector-hive
 
 If you don't have postgres server with vector extension installed, you can use docker to run it.
 
-```bash
+```bash copy
 docker run -d \
   --name postgres-vector \
   -e POSTGRES_USER=your_user \
@@ -77,7 +77,7 @@ docker run -d \
 
 Then, we will fill the next environment variables files
 
-```env
+```env copy
 // .env
 PROJECT_API_PORT=37001
 DATABASE_URL=postgresql://your_user:your_password@host.docker.internal:5432/your_database
@@ -86,7 +86,7 @@ API_KEY=your_optional_api_key  # Optional: If set, all requests except GET /heal
 ```
 
 and run the next command
-```bash
+```bash copy
 docker pull ghcr.io/wrtnlabs/connector-hive:latest && \
 docker run -d \
   --name connector-hive \
@@ -99,7 +99,7 @@ Good!
 
 Now, you can use the `connector-hive` server with the `pg-vector-selector` library.
 
-```typescript
+```typescript filename="src/main.ts" copy
 const selectorExecute = AgenticaPgVectorSelector.boot<"chatgpt">(
   'http://localhost:37001'
 );

--- a/website/content/docs/setup.mdx
+++ b/website/content/docs/setup.mdx
@@ -6,17 +6,17 @@ import { Tabs } from 'nextra/components'
 ## Boilerplate
 <Tabs items={['npm', 'pnpm', 'yarn']}>
   <Tabs.Tab>
-```bash filename="Terminal"
+```bash filename="Terminal" copy
 npx agentica start <directory> 
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```bash filename="Terminal"
+```bash filename="Terminal" copy
 npx agentica start <directory> --manager pnpm
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```bash filename="Terminal"
+```bash filename="Terminal" copy
 # YARN BERRY IS NOT SUPPORTED
 npx agentica start <directory> --manager yarn
 ```
@@ -188,7 +188,7 @@ Just install `@agentica/rpc` and [`tgrid`](https://tgrid.com) packages.
 
 
 ## Standalone Application
-```bash filename="Terminal"
+```bash filename="Terminal" copy
 npm install @agentica/core @samchon/openapi typia
 npx typia setup
 

--- a/website/content/docs/websocket/client.mdx
+++ b/website/content/docs/websocket/client.mdx
@@ -3,14 +3,14 @@ title: Agentica > Guide Documents > WebSocket Protocol > Client Application
 ---
 
 ## Setup
-```bash filename="Terminal"
+```bash filename="Terminal" copy
 npm install @agentica/rpc tgrid
 ```
 
 
 
 ## Development
-```typescript filenam="client/src/main.ts" showLineNumbers
+```typescript filenam="client/src/main.ts" showLineNumbers copy
 import { IAgenticaRpcListener, IAgenticaRpcService } from "@agentica/rpc";
 import { Driver, WebSocketConnector } from "tgrid";
 

--- a/website/content/docs/websocket/index.mdx
+++ b/website/content/docs/websocket/index.mdx
@@ -18,7 +18,7 @@ However, don't be afraid of WebSocket application development. Below is the exam
   "NestJS Server",
 ]}>
   <Tabs.Tab>
-```typescript filename="client/src/main.ts" showLineNumbers
+```typescript filename="client/src/main.ts" showLineNumbers copy
 import { IAgenticaRpcListener, IAgenticaRpcService } from "@agentica/rpc";
 import { Driver, WebSocketConnector } from "tgrid";
 
@@ -42,7 +42,7 @@ await driver.conversate("Hello, what you can do?");
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="nodejs/src/main.ts" showLineNumbers
+```typescript filename="nodejs/src/main.ts" showLineNumbers copy
 import { Agentica } from "@agentica/core";
 import {
   AgenticaRpcService,
@@ -68,7 +68,7 @@ await server.open(3_001, async (acceptor) => {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="nestjs/src/chat.controller.ts" showLineNumbers
+```typescript filename="nestjs/src/chat.controller.ts" showLineNumbers copy
 import { AgenticaRpcService, IAgenticaRpcListener } from "@agentica/rpc";
 import { WebSocketRoute } from "@nestia/core";
 import { Controller } from "@nestjs/common";
@@ -120,7 +120,7 @@ npx typia setup
 ```
 
 ### Client Application
-```bash filename="Terminal"
+```bash filename="Terminal" copy
 npm install @agentica/rpc tgrid
 ```
 

--- a/website/content/docs/websocket/nestjs.mdx
+++ b/website/content/docs/websocket/nestjs.mdx
@@ -15,7 +15,7 @@ npx nestia setup
 
 
 ## Bootstrap
-```typescript filename="nestj/src/main.ts" showLineNumbers
+```typescript filename="nestjs/src/main.ts" showLineNumbers copy
 import { WebSocketAdaptor } from "@nestia/core";
 import { INestApplication } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
@@ -30,7 +30,7 @@ await app.listen(3_001, "0.0.0.0");
 
 
 ## API Controller
-```typescript filename="nestjs/src/chat.controller.ts" showLineNumbers
+```typescript filename="nestjs/src/chat.controller.ts" showLineNumbers copy
 import { AgenticaRpcService, IAgenticaRpcListener } from "@agentica/rpc";
 import { WebSocketRoute } from "@nestia/core";
 import { Controller } from "@nestjs/common";

--- a/website/content/docs/websocket/nodejs.mdx
+++ b/website/content/docs/websocket/nodejs.mdx
@@ -12,7 +12,7 @@ npx typia setup
 
 
 ## Development
-```typescript filename="nodejs/src/main.ts" showLineNumbers
+```typescript filename="nodejs/src/main.ts" showLineNumbers copy
 import { Agentica } from "@agentica/core";
 import {
   AgenticaRpcService,

--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -12,7 +12,7 @@ Don't compose complicate agent graph or workflow, but just deliver **Swagger/Ope
 
 Look at the below demonstration, and feel how `agentica` is easy and powerful. You can let users to search and purchase products only with conversation texts. The backend API and TypeScript class functions would be adequately called in the AI chatbot with LLM function calling.
 
-```typescript showLineNumbers
+```typescript showLineNumbers =
 import { Agentica } from "@agentica/core";
 import typia from "typia";
 

--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -12,7 +12,7 @@ Don't compose complicate agent graph or workflow, but just deliver **Swagger/Ope
 
 Look at the below demonstration, and feel how `agentica` is easy and powerful. You can let users to search and purchase products only with conversation texts. The backend API and TypeScript class functions would be adequately called in the AI chatbot with LLM function calling.
 
-```typescript showLineNumbers =
+```typescript showLineNumbers
 import { Agentica } from "@agentica/core";
 import typia from "typia";
 


### PR DESCRIPTION
This pull request includes changes to multiple documentation files, primarily adding the `copy` option to code blocks for easier copying of code samples. The most important changes are grouped by the affected files.

Changes to `website/content/docs/plugins/benchmark.mdx`:

* Added `copy` option to all `typescript` code blocks for easier copying. [[1]](diffhunk://#diff-1c92e38dd15b636af53e6a1e885e499fe1abb8aabf6914c0a1f84b9b7d6711e3L40-R40) [[2]](diffhunk://#diff-1c92e38dd15b636af53e6a1e885e499fe1abb8aabf6914c0a1f84b9b7d6711e3L63-R63) [[3]](diffhunk://#diff-1c92e38dd15b636af53e6a1e885e499fe1abb8aabf6914c0a1f84b9b7d6711e3L206-R206) [[4]](diffhunk://#diff-1c92e38dd15b636af53e6a1e885e499fe1abb8aabf6914c0a1f84b9b7d6711e3L330-R330) [[5]](diffhunk://#diff-1c92e38dd15b636af53e6a1e885e499fe1abb8aabf6914c0a1f84b9b7d6711e3L467-R467) [[6]](diffhunk://#diff-1c92e38dd15b636af53e6a1e885e499fe1abb8aabf6914c0a1f84b9b7d6711e3L510-R510)

Changes to `website/content/docs/plugins/pg-vector-selector.mdx`:

* Added `copy` option to `bash`, `typescript`, and `env` code blocks for easier copying. [[1]](diffhunk://#diff-dc874cd35a04f59af58716633e10072337546fd6a9d2076503ddbbeb607baa27L12-R20) [[2]](diffhunk://#diff-dc874cd35a04f59af58716633e10072337546fd6a9d2076503ddbbeb607baa27L68-R68) [[3]](diffhunk://#diff-dc874cd35a04f59af58716633e10072337546fd6a9d2076503ddbbeb607baa27L80-R80) [[4]](diffhunk://#diff-dc874cd35a04f59af58716633e10072337546fd6a9d2076503ddbbeb607baa27L89-R89) [[5]](diffhunk://#diff-dc874cd35a04f59af58716633e10072337546fd6a9d2076503ddbbeb607baa27L102-R102)

Changes to `website/content/docs/setup.mdx`:

* Added `copy` option to `bash` code blocks in the setup instructions. [[1]](diffhunk://#diff-d2c04bd6d5eafe124f8a66ed53f5b323a36876d2d98fe055a123d50c6faf7860L9-R19) [[2]](diffhunk://#diff-d2c04bd6d5eafe124f8a66ed53f5b323a36876d2d98fe055a123d50c6faf7860L191-R191)

Changes to `website/content/docs/websocket/client.mdx`:

* Added `copy` option to `bash` and `typescript` code blocks for easier copying.

Changes to `website/content/docs/websocket/index.mdx`:

* Added `copy` option to `typescript` and `bash` code blocks for easier copying. [[1]](diffhunk://#diff-77b071a167492a27529e9c9bc5b0a69f9ee3def5d56ee7de0cc6f43f4ea534abL21-R21) [[2]](diffhunk://#diff-77b071a167492a27529e9c9bc5b0a69f9ee3def5d56ee7de0cc6f43f4ea534abL45-R45) [[3]](diffhunk://#diff-77b071a167492a27529e9c9bc5b0a69f9ee3def5d56ee7de0cc6f43f4ea534abL71-R71) [[4]](diffhunk://#diff-77b071a167492a27529e9c9bc5b0a69f9ee3def5d56ee7de0cc6f43f4ea534abL123-R123)

Changes to `website/content/docs/websocket/nestjs.mdx`:

* Added `copy` option to `typescript` code blocks for easier copying. [[1]](diffhunk://#diff-20fa5513235980c756a5674d492ee602fa4e6e81b732594d9184a25d60d34f3eL18-R18) [[2]](diffhunk://#diff-20fa5513235980c756a5674d492ee602fa4e6e81b732594d9184a25d60d34f3eL33-R33)

Changes to `website/content/docs/websocket/nodejs.mdx`:

* Added `copy` option to `typescript` code blocks for easier copying.

Change to `website/content/docs/concepts/function-calling.mdx`:

* Added `copy` option to `typescript` code block for easier copying.