### PR TITLE
fix(cli): replace rimraf with native fs.rm

### DIFF
--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -295,12 +295,11 @@ namespace AgenticaStarter {
     await downloadTemplate(`github:wrtnlabs/agentica.template.${type}`, {
       dir: directory,
     });
-    process.chdir(directory);
 
     console.log("✅ Template downloaded");
 
     // REMOVE .GIT DIRECTORY
-    cp.execSync("npx rimraf .git");
-    cp.execSync("npx rimraf .github/dependabot.yml");
+    await fs.rm(path.join(directory, ".git"), { recursive: true });
+    await fs.rm(path.join(directory, ".github/dependabot.yml"));
   };
 }


### PR DESCRIPTION
Replace third-party rimraf dependency with Node's native fs.rm for removing .git directory and .github/dependabot.yml. if use run `npx rimraf`, even user use pnpm, npm is used.

===
This pull request includes changes to the `AgenticaStart` namespace in the `packages/cli/src/executable/AgenticaStart.ts` file. The primary focus of these changes is to improve the method of removing directories by using asynchronous file system operations instead of synchronous ones.

Key changes include:

* [`packages/cli/src/executable/AgenticaStart.ts`](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aL176-R179): Replaced synchronous `cp.execSync` calls with asynchronous `fs.rm` calls to remove the `.git` directory and the `.github/dependabot.yml` file.