### PR TITLE
fix(cli): make prettier dynamic import

### DIFF
--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -3,7 +3,6 @@ import cp from "child_process";
 import fs from "fs/promises";
 import inquirer, { QuestionCollection } from "inquirer";
 import path from "path";
-import prettier from "prettier";
 import typia from "typia";
 
 import { Connector } from "../bases/Connector";
@@ -261,9 +260,13 @@ namespace AgenticaStarter {
     taskName: string;
     content: string;
   }): Promise<void> => {
-    const formattedFileContent = await prettier.format(props.content, {
-      parser: "typescript",
-    });
+    /** prettier is not in the dependencies */
+    const formattedFileContent =
+      await import("prettier")
+        .then((prettier) => prettier.format(props.content, {
+          parser: "typescript",
+        }))
+        .catch(() => props.content);
 
     await fs.writeFile(props.filePath, formattedFileContent);
     console.log(`✅ ${props.taskName} created`);


### PR DESCRIPTION
Use dynamic import for prettier and handle the case when it's not available in dependencies by falling back to the original content. Otherwise, the import will fail and the CLI will not work.


This pull request includes changes to the `packages/cli/src/executable/AgenticaStart.ts` file to address dependency management and improve the formatting process. The key changes involve removing a direct import of `prettier` and handling it dynamically within the function.

Dependency management and formatting process:

* Removed the direct import of `prettier` to avoid issues with missing dependencies. (`[packages/cli/src/executable/AgenticaStart.tsL6](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aL6)`)
* Updated the formatting function to dynamically import `prettier` and handle cases where the import fails by using the original content. (`[packages/cli/src/executable/AgenticaStart.tsL264-R269](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aL264-R269)`)