### PR TITLE
fix(cli): replace axios with native fetch

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,6 @@
     "src"
   ],
   "dependencies": {
-    "axios": "^1.8.2",
     "chalk": "^4.1.2",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
@@ -60,3 +59,4 @@
     "typia": "^8.0.0"
   }
 }
+

--- a/packages/cli/src/utils/getNpmPackages.ts
+++ b/packages/cli/src/utils/getNpmPackages.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import typia, { tags } from "typia";
 
 export interface INpmPackages {
@@ -15,10 +14,11 @@ export const getNpmPackages = async (): Promise<
   { name: string; value: string }[]
 > => {
   try {
-    const response = await axios.get(
+    const response = await fetch(
       "https://registry.npmjs.org/-/v1/search?text=scope:@wrtnlabs&size=10000",
     );
-    const data = typia.assert<INpmPackages>(response.data);
+    const responseJson = await response.json();
+    const data = typia.assert<INpmPackages>(responseJson);
 
     return data.objects
       .map((pkg: any) => pkg.package.name)


### PR DESCRIPTION
Removed axios dependency from packages/cli by replacing the API call with native fetch in getNpmPackages.ts, reducing bundle size and dependencies.

This pull request includes changes to the `packages/cli` to remove the `axios` dependency and replace it with the native `fetch` API for making HTTP requests. The changes also include minor formatting adjustments.

Dependency removal and replacement:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L45): Removed the `axios` dependency.
* [`packages/cli/src/utils/getNpmPackages.ts`](diffhunk://#diff-57441632a2a5129de1e51727b2b1e77711dd035485a67d06ef36ce1f7964962bL1): Removed the import statement for `axios` and replaced the `axios.get` call with the `fetch` API. [[1]](diffhunk://#diff-57441632a2a5129de1e51727b2b1e77711dd035485a67d06ef36ce1f7964962bL1) [[2]](diffhunk://#diff-57441632a2a5129de1e51727b2b1e77711dd035485a67d06ef36ce1f7964962bL18-R21)

Formatting adjustments:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758R62): Added a newline at the end of the file.