### PR TITLE
feat(cli): add support for Bun package manager

### DIFF
--- a/packages/cli/src/bases/Package.ts
+++ b/packages/cli/src/bases/Package.ts
@@ -38,6 +38,8 @@ export namespace Package {
             return `yarn add ${pkg}`;
           case "pnpm":
             return `pnpm add ${pkg}`;
+          case "bun":
+            return `bun add ${pkg}`;
         }
       };
 

--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -98,6 +98,7 @@ export namespace AgenticaStart {
             name: `yarn (berry ${chalk.blueBright("is not supported")})`,
             value: "yarn",
           },
+          "bun",
         ],
       },
       input.options.project

--- a/packages/cli/src/utils/getQuestions.ts
+++ b/packages/cli/src/utils/getQuestions.ts
@@ -20,6 +20,7 @@ export const getQuestions = (
         "npm",
         "pnpm",
         `yarn (berry ${chalk.blueBright("is not supported")})`,
+        "bun",
       ],
     },
     {

--- a/packages/cli/src/utils/types/PackageManager.ts
+++ b/packages/cli/src/utils/types/PackageManager.ts
@@ -1,1 +1,1 @@
-export type PackageManager = "npm" | "yarn" | "pnpm";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun"


### PR DESCRIPTION
Add Bun as an available package manager option throughout the CLI:
- Update PackageManager type to include "bun"
- Add Bun selection option in interactive prompts
- Implement package installation command for Bun

This pull request introduces support for the `bun` package manager in the CLI tool. The most important changes include adding `bun` to the list of supported package managers and updating relevant functions and types to accommodate this new option.

Support for `bun` package manager:

* [`packages/cli/src/bases/Package.ts`](diffhunk://#diff-f44345d2056ed241a54344cbfffe342936713a3f226be146eee4543474f8e6ffR41-R42): Added a case for `bun` in the `getAddCommand` function.
* [`packages/cli/src/executable/AgenticaStart.ts`](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aR101): Included `bun` in the list of package managers in the `AgenticaStart` namespace.
* [`packages/cli/src/utils/getQuestions.ts`](diffhunk://#diff-e60903398efc9edce9eaa7dc99c5e105a7a21cdc570bf4364b0dbf5e539c8fceR23): Added `bun` to the list of package managers in the `getQuestions` function.
* [`packages/cli/src/utils/types/PackageManager.ts`](diffhunk://#diff-38053c74192735bf93e76b69dc0d81baa4c184a2a2c414a292c3d59bd809719bL1-R1): Updated the `PackageManager` type to include `bun`.