### PR TITLE
feat(cli): add exhaustive type check for package managers

### DIFF
--- a/packages/cli/src/bases/Package.ts
+++ b/packages/cli/src/bases/Package.ts
@@ -40,6 +40,11 @@ export namespace Package {
             return `pnpm add ${pkg}`;
           case "bun":
             return `bun add ${pkg}`;
+          default:
+            /** exhaustive check */
+            packageManager satisfies never;
+
+            throw new Error(`Unsupported package manager: ${packageManager as unknown as string}`);
         }
       };
 


### PR DESCRIPTION
Add TypeScript exhaustive type checking for package managers to ensure all cases are properly handled. The change improves type safety by making future additions to package manager types fail compilation if not explicitly handled in the switch statement.

This pull request includes a change to the `Package` namespace in the `packages/cli/src/bases/Package.ts` file to improve error handling for unsupported package managers.

Error handling improvement:

* [`packages/cli/src/bases/Package.ts`](diffhunk://#diff-f44345d2056ed241a54344cbfffe342936713a3f226be146eee4543474f8e6ffR41-R45): Added a default case to the `switch` statement to handle unsupported package managers by throwing an error, ensuring exhaustive checks.