### PR TITLE
fix: remove git command execution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,11 +45,11 @@
     "chalk": "^4.1.2",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
+    "giget": "^1",
     "inquirer": "^8.2.5",
     "package-manager-detector": "^0.2.0"
   },
   "devDependencies": {
-    "@types/axios": "^0.14.4",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.19.76",
     "rimraf": "^6.0.1",

--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -291,6 +291,8 @@ namespace AgenticaStarter {
     await downloadTemplate(`github:wrtnlabs/agentica.template.${type}`, {
       dir: directory,
     });
+    process.chdir(directory);
+
     console.log("✅ Template cloned");
 
     // REMOVE .GIT DIRECTORY

--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -293,7 +293,7 @@ namespace AgenticaStarter {
     });
     process.chdir(directory);
 
-    console.log("✅ Template cloned");
+    console.log("✅ Template downloaded");
 
     // REMOVE .GIT DIRECTORY
     cp.execSync("npx rimraf .git");

--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import cp from "child_process";
 import fs from "fs/promises";
+import { downloadTemplate } from "giget";
 import inquirer, { QuestionCollection } from "inquirer";
 import path from "path";
 import prettier from "prettier";
@@ -230,7 +231,7 @@ namespace AgenticaStarter {
         indexFileContent: string;
       }>,
     ) => {
-      clone(option, input.projectName);
+      await writeTemplate(option, input.projectName);
 
       // Create Agentica code
       const importCode = Connector.create("import")({
@@ -282,17 +283,15 @@ namespace AgenticaStarter {
   /**
    * Git Clone from template repository.
    */
-  export const clone = (type: ProjectOptionValue, directory: string): void => {
-    const execute = (command: string): void => {
-      console.log(`\n$ ${command}`);
-      cp.execSync(command, { stdio: "inherit" });
-    };
-
+  export const writeTemplate = async (
+    type: ProjectOptionValue,
+    directory: string,
+  ): Promise<void> => {
     // COPY PROJECTS
-    execute(
-      `git clone git@github.com:wrtnlabs/agentica.template.${type} ${directory}`,
-    );
-    process.chdir(directory);
+    await downloadTemplate(`github:wrtnlabs/agentica.template.${type}`, {
+      dir: directory,
+    });
+    console.log("✅ Template cloned");
 
     // REMOVE .GIT DIRECTORY
     cp.execSync("npx rimraf .git");

--- a/packages/cli/src/utils/getNpmPackages.ts
+++ b/packages/cli/src/utils/getNpmPackages.ts
@@ -17,11 +17,12 @@ export const getNpmPackages = async (): Promise<
     const response = await fetch(
       "https://registry.npmjs.org/-/v1/search?text=scope:@wrtnlabs&size=10000",
     );
-    const responseJson = await response.json();
+    const responseJson = (await response.json()) as INpmPackages;
+
     const data = typia.assert<INpmPackages>(responseJson);
 
     return data.objects
-      .map((pkg: any) => pkg.package.name)
+      .map((pkg) => pkg.package.name)
       .filter((name: string) => {
         // shared is not connector package. This is connector util package.
         if (name === "@wrtnlabs/connector-shared") {


### PR DESCRIPTION
This pull request includes several changes to the `packages/cli` that improve the handling of project templates and update dependencies. The most important changes include replacing the `clone` function with `writeTemplate`, removing `axios` in favor of `fetch`, and updating the dependencies in `package.json`.

### Improvements to project template handling:

* [`packages/cli/src/executable/AgenticaStart.ts`](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aR4): Replaced the `clone` function with `writeTemplate` to use `giget` for downloading project templates. This change includes importing `downloadTemplate` from `giget` and modifying the function to use `downloadTemplate` instead of `git clone`. [[1]](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aR4) [[2]](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aL233-R234) [[3]](diffhunk://#diff-a96f3ceac5d81d41e64a77cf1f4e42889aba41e66ac7f6d3475782be7f379b7aL285-R294)

### Dependency updates:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L45-L53): Removed `axios` and its types, and added `giget` as a new dependency.

### Codebase simplification:

* [`packages/cli/src/utils/getNpmPackages.ts`](diffhunk://#diff-57441632a2a5129de1e51727b2b1e77711dd035485a67d06ef36ce1f7964962bL1): Removed `axios` and replaced it with `fetch` for making HTTP requests, simplifying the code and reducing dependencies. [[1]](diffhunk://#diff-57441632a2a5129de1e51727b2b1e77711dd035485a67d06ef36ce1f7964962bL1) [[2]](diffhunk://#diff-57441632a2a5129de1e51727b2b1e77711dd035485a67d06ef36ce1f7964962bL18-R24)