### PR TITLE
fix(cli): typia should be the `dependencies`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,8 @@
     "comment-json": "^4.2.3",
     "giget": "^1",
     "inquirer": "^8.2.5",
-    "package-manager-detector": "^0.2.0"
+    "package-manager-detector": "^0.2.0",
+    "typia": "^8.0.0"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.3",
@@ -55,8 +56,7 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
-    "typescript": "~5.8.2",
-    "typia": "^8.0.0"
+    "typescript": "~5.8.2"
   }
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `packages/cli/package.json` file. The change involves moving the `typia` package from `devDependencies` to `dependencies`. 

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L50-R59): Moved `typia` package from `devDependencies` to `dependencies` section.