### PR TITLE
Guidance of system prompt configuration

### DIFF
--- a/website/content/docs/core/config.mdx
+++ b/website/content/docs/core/config.mdx
@@ -159,6 +159,16 @@ await agent.conversate("Hello, I want to refund my shoes.");
   </Tabs.Tab>
 </Tabs>
 
+System prompts for each [internal agents](/docs/concepts/function-calling/#orchestration-strategy).
+
+If you configure `IAgenticaSystemPrompt` properties, you can change the system prompt contents.
+
+Here is the list of default system prompts, and it would be changed to what you've configured. Reading the `IAgenticaSystemPrompt` type carefully and referencing below snippet, configure the system prompts for guiding the agent to the right way.
+
+Also, the `common` property configure will affect to the every internal agents. If you are developing a chatbot of counseling, you can guide the agent to use the polite and gentle tone by configuring the `common` property. When your agent needs to follow a specific policy, the `common` property is the best place to configure too.
+
+   - https://github.com/wrtnlabs/agentica/tree/main/packages/core/prompts
+
 
 
 


### PR DESCRIPTION
This pull request includes updates to the documentation to provide more detailed guidance on configuring system prompts for internal agents. The changes focus on explaining how to use the `IAgenticaSystemPrompt` properties and the impact of the `common` property configuration.

Documentation updates:

* [`website/content/docs/core/config.mdx`](diffhunk://#diff-0c3fc75dd202f085970b239482af7d2cd71137c3f921edb19eeb0e075fc8bbccR162-R171): Added a detailed explanation of system prompts for internal agents, including how to configure `IAgenticaSystemPrompt` properties and the `common` property to guide agents' behavior.