### PR TITLE
fix(cli): wrong project configure on standalone project type

### DIFF
--- a/packages/cli/src/bases/Package.ts
+++ b/packages/cli/src/bases/Package.ts
@@ -15,8 +15,8 @@ export namespace Package {
       description: "",
       scripts: {
         build: "tsc",
-        dev: `ts-node ${input.projectName}/cli.ts`,
-        start: `node ${input.projectName}/cli.js`,
+        dev: `ts-node src/index.ts`,
+        start: `node dist/index.js`,
       },
     };
 
@@ -44,7 +44,9 @@ export namespace Package {
             /** exhaustive check */
             packageManager satisfies never;
 
-            throw new Error(`Unsupported package manager: ${packageManager as unknown as string}`);
+            throw new Error(
+              `Unsupported package manager: ${packageManager as unknown as string}`,
+            );
         }
       };
 

--- a/packages/cli/src/bases/Package.ts
+++ b/packages/cli/src/bases/Package.ts
@@ -14,6 +14,7 @@ export namespace Package {
       version: "0.0.1",
       description: "",
       scripts: {
+        prepare: "ts-patch install",
         build: "tsc",
         dev: `ts-node src/index.ts`,
         start: `node dist/index.js`,
@@ -55,11 +56,10 @@ export namespace Package {
         "typia",
         "dotenv",
         "@agentica/core",
-        "readline",
         ...input.services.map((s) => `@wrtnlabs/connector-${s}`),
       ];
 
-      const devDependencies = ["ts-node", "typescript"];
+      const devDependencies = ["ts-node", "typescript", "ts-patch"];
 
       // install existing dependencies
       console.log("🚀 Installing existing dependencies...");

--- a/packages/cli/src/bases/Tsconfig.ts
+++ b/packages/cli/src/bases/Tsconfig.ts
@@ -66,7 +66,7 @@ export namespace Tsconfig {
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./lib" /* Specify an output folder for all emitted files. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */

--- a/packages/cli/src/functional/AgenticaStarter.ts
+++ b/packages/cli/src/functional/AgenticaStarter.ts
@@ -47,7 +47,7 @@ export namespace AgenticaStarter {
         const agenticaCode = Connector.createAll({ services: input.services });
 
         await writeTypescriptFile({
-          filePath: path.join(input.projectPath, "src/agent.ts"),
+          filePath: path.join(input.projectPath, "src/index.ts"),
           taskName: "Agentica code",
           content: agenticaCode,
         });


### PR DESCRIPTION
The standalone project is single execution file, never be a library  
so i rename the `agent.ts` to `index.ts` and `lib` to `dist`  
  
---
This pull request includes several changes to improve the file structure and error handling in the `packages/cli` module. The most important changes include updating script paths, modifying the output directory, and refining error messages.

### Script Path Updates:
* [`packages/cli/src/bases/Package.ts`](diffhunk://#diff-f44345d2056ed241a54344cbfffe342936713a3f226be146eee4543474f8e6ffL18-R19): Updated the `dev` and `start` script paths to use `src/index.ts` and `dist/index.js` respectively.

### Output Directory Modification:
* [`packages/cli/src/bases/Tsconfig.ts`](diffhunk://#diff-e83d9ad6448a97275f7ef71dfb1126da526faded23cc06e62977feb75af3962dL69-R69): Changed the `outDir` configuration from `./lib` to `./dist` to specify the output folder for all emitted files.

### Error Handling Improvement:
* [`packages/cli/src/bases/Package.ts`](diffhunk://#diff-f44345d2056ed241a54344cbfffe342936713a3f226be146eee4543474f8e6ffL47-R49): Improved the error message formatting for unsupported package managers.

### File Path Update:
* [`packages/cli/src/functional/AgenticaStarter.ts`](diffhunk://#diff-7909b5d48e0fb990265602c41ab017c1c0d1c2b072c0721cfd829136a538bc11L50-R50): Updated the file path for the generated TypeScript file from `src/agent.ts` to `src/index.ts`.