### PR TITLE
feat(core): add text event dispatch on 'initialize' step

### DIFF
--- a/packages/core/src/chatgpt/ChatGptInitializeFunctionAgent.ts
+++ b/packages/core/src/chatgpt/ChatGptInitializeFunctionAgent.ts
@@ -4,8 +4,10 @@ import typia from "typia";
 
 import { AgenticaContext } from "../context/AgenticaContext";
 import { __IChatInitialApplication } from "../context/internal/__IChatInitialApplication";
+import { AgenticaTextEvent } from "../events/AgenticaTextEvent";
 import { AgenticaDefaultPrompt } from "../internal/AgenticaDefaultPrompt";
 import { AgenticaSystemPrompt } from "../internal/AgenticaSystemPrompt";
+import { MPSCUtil } from "../internal/MPSCUtil";
 import { StreamUtil } from "../internal/StreamUtil";
 import { AgenticaPrompt } from "../prompts/AgenticaPrompt";
 import { AgenticaTextPrompt } from "../prompts/AgenticaTextPrompt";
@@ -56,8 +58,75 @@ export namespace ChatGptInitializeFunctionAgent {
       parallel_tool_calls: false,
     });
 
-    const chunks = await StreamUtil.readAll(completionStream);
-    const completion = ChatGptCompletionMessageUtil.merge(chunks);
+    const textContext: ({
+      content: string;
+    } & ReturnType<typeof MPSCUtil.create<string>>)[] = [];
+
+    const completion = await StreamUtil.reduce<
+      OpenAI.ChatCompletionChunk,
+      Promise<OpenAI.ChatCompletion>
+    >(completionStream, async (accPromise, chunk) => {
+      const acc = await accPromise;
+      const registerContext = (
+        choices: OpenAI.ChatCompletionChunk.Choice[],
+      ) => {
+        for (const choice of choices) {
+          if (choice.finish_reason) {
+            textContext[choice.index]?.close();
+            continue;
+          }
+          if (!choice.delta.content) {
+            continue;
+          }
+
+          if (textContext[choice.index]) {
+            textContext[choice.index]!.content += choice.delta.content;
+            textContext[choice.index]!.produce(choice.delta.content);
+            continue;
+          }
+
+          const { consumer, produce, close, waitClosed, waitUntilEmpty, done } =
+            MPSCUtil.create<string>();
+
+          textContext[choice.index] = {
+            content: choice.delta.content,
+            consumer,
+            produce,
+            close,
+            waitClosed,
+            waitUntilEmpty,
+            done,
+          };
+          produce(choice.delta.content);
+
+          void ctx.dispatch(
+            new AgenticaTextEvent({
+              role: "assistant",
+              stream: consumer,
+              done,
+              get: () => textContext[choice.index]?.content ?? "",
+              join: async () => {
+                await waitClosed();
+                return textContext[choice.index]!.content;
+              },
+            }),
+          );
+        }
+      };
+
+      if (acc.object === "chat.completion.chunk") {
+        registerContext([acc, chunk].flatMap((acc) => acc.choices));
+        return ChatGptCompletionMessageUtil.merge([acc, chunk]);
+      }
+
+      registerContext(chunk.choices);
+      return ChatGptCompletionMessageUtil.accumulate(acc, chunk);
+    });
+
+    if (!completion) {
+      throw new Error("No completion received");
+    }
+
     //----
     // PROCESS COMPLETION
     //----
@@ -67,7 +136,6 @@ export namespace ChatGptInitializeFunctionAgent {
         choice.message.role === "assistant" &&
         !!choice.message.content?.length
       ) {
-        // @TODO this logic should call the dispatch function
         prompts.push(
           new AgenticaTextPrompt({
             role: "assistant",

--- a/test/src/features/test_base_streaming_describe.ts
+++ b/test/src/features/test_base_streaming_describe.ts
@@ -173,7 +173,7 @@ export async function test_base_streaming_describe(): Promise<void | false> {
   if (!describeEvent) {
     throw new Error("Could not find describe event");
   }
-  console.log("describeEvent.done", describeEvent.done);
+
   // Check if describe event includes executions array
   if (!describeEvent.executes || describeEvent.executes.length === 0) {
     throw new Error("describe event has no executions information");


### PR DESCRIPTION
fix it...
This is a request from @kimulchan.....


https://github.com/wrtnlabs/agentica/pull/83#discussion_r1986604605
<img width="727" alt="스크린샷 2025-03-18 오후 6 11 57" src="https://github.com/user-attachments/assets/7a048fa0-2d81-4162-a3df-44fa2900216d" />

---

This pull request includes several changes to the `ChatGptInitializeFunctionAgent` and a test file. The most important changes involve adding new imports, updating the completion stream handling, and removing unnecessary console logging.

### Changes to `ChatGptInitializeFunctionAgent`:

* Added new imports for `AgenticaTextEvent` and `MPSCUtil` to support new functionality.
* Replaced the `StreamUtil.readAll` method with a more complex stream processing approach using `StreamUtil.reduce` and `MPSCUtil.create` to handle text context and dispatch events.
* Removed a `TODO` comment related to dispatching logic in the assistant role message handling.

### Changes to test file:

* Removed an unnecessary `console.log` statement in the `test_base_streaming_describe` function.