### PR TITLE
fix(cli): removed unused deps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,6 @@
     "bin"
   ],
   "dependencies": {
-    "commander": "^10.0.0",
     "giget": "^1",
     "inquirer": "^8.2.5"
   },
@@ -54,6 +53,7 @@
     "@ryoppippi/unplugin-typia": "^1.2.0",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^20.14.8",
+    "commander": "^10.0.0",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
     "typia": "^8.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,10 +40,8 @@
   ],
   "dependencies": {
     "commander": "^10.0.0",
-    "comment-json": "^4.2.3",
     "giget": "^1",
     "inquirer": "^8.2.5",
-    "package-manager-detector": "^0.2.0",
     "typia": "^8.0.0"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,8 +41,7 @@
   "dependencies": {
     "commander": "^10.0.0",
     "giget": "^1",
-    "inquirer": "^8.2.5",
-    "typia": "^8.0.0"
+    "inquirer": "^8.2.5"
   },
   "engines": {
     "node": ">=20.12.0"
@@ -57,6 +56,7 @@
     "@types/node": "^20.14.8",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
+    "typia": "^8.0.0",
     "typescript": "~5.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,18 +205,12 @@ importers:
       commander:
         specifier: ^10.0.0
         version: 10.0.1
-      comment-json:
-        specifier: ^4.2.3
-        version: 4.2.5
       giget:
         specifier: ^1
         version: 1.2.5
       inquirer:
         specifier: ^8.2.5
         version: 8.2.6
-      package-manager-detector:
-        specifier: ^0.2.0
-        version: 0.2.11
       typia:
         specifier: ^8.0.0
         version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
       inquirer:
         specifier: ^8.2.5
         version: 8.2.6
-      typia:
-        specifier: ^8.0.0
-        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
     devDependencies:
       '@rslib/core':
         specifier: ^0.5.4
@@ -236,6 +233,9 @@ importers:
       typescript:
         specifier: ~5.8.2
         version: 5.8.2
+      typia:
+        specifier: ^8.0.0
+        version: 8.0.0(@samchon/openapi@3.0.0)(typescript@5.8.2)
     optionalDependencies:
       prettier:
         specifier: '>=2.4.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,6 @@ importers:
 
   packages/cli:
     dependencies:
-      commander:
-        specifier: ^10.0.0
-        version: 10.0.1
       giget:
         specifier: ^1
         version: 1.2.5
@@ -224,6 +221,9 @@ importers:
       '@types/node':
         specifier: ^20.14.8
         version: 20.17.23
+      commander:
+        specifier: ^10.0.0
+        version: 10.0.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.17.23)(typescript@5.8.2)


### PR DESCRIPTION
This pull request includes changes to the `packages/cli/package.json` and `pnpm-lock.yaml` files to remove unused dependencies.

Dependency removal:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L43-L46): Removed `comment-json` and `package-manager-detector` dependencies. and move `typia` from deps to devDeps
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL208-L219): Removed `comment-json` and `package-manager-detector` dependencies from the importers section.