### PR TITLE
fix(cli): add ts-patch install first when installing packages.

### DIFF
--- a/packages/cli/src/bases/Package.ts
+++ b/packages/cli/src/bases/Package.ts
@@ -51,6 +51,19 @@ export namespace Package {
         }
       };
 
+      // install ts-patch First.
+      execSync(installCmd("ts-patch"), {
+        cwd: input.projectPath,
+        stdio: "inherit",
+      });
+
+      // install existing dependencies
+      console.log("🚀 Installing existing dependencies...");
+      execSync(`${packageManager} install`, {
+        cwd: input.projectPath,
+        stdio: "inherit",
+      });
+
       const dependencies = [
         "openai",
         "typia",
@@ -59,14 +72,7 @@ export namespace Package {
         ...input.services.map((s) => `@wrtnlabs/connector-${s}`),
       ];
 
-      const devDependencies = ["ts-node", "typescript", "ts-patch"];
-
-      // install existing dependencies
-      console.log("🚀 Installing existing dependencies...");
-      execSync(`${packageManager} install`, {
-        cwd: input.projectPath,
-        stdio: "inherit",
-      });
+      const devDependencies = ["ts-node", "typescript"];
 
       dependencies.forEach((dep) => {
         console.log(`🚀 Installing ${dep}...`);


### PR DESCRIPTION
## Description
- when user execute agentica cli, ts-pacth is not prepared. so that occurs the `ts-patch not installed.` error.
![image](https://github.com/user-attachments/assets/9b31f682-6e21-4e48-ab0b-39933697f608)
