### PR TITLE
manage pnpm & node version by pnpm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
       - uses: pnpm/action-setup@v2
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           node-version: 20.x
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.15.9
       - name: Install dependencies
         run: pnpm install
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
           node-version: 20.x
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Publish to NPM
         run: npm run package:latest
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v2
       - name: Publish to NPM

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           node-version: 20.x
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Root
         run: pnpm install
       - name: Website

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
       - uses: pnpm/action-setup@v2
       - name: Root
         run: pnpm install

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+use-node-version=22.14.0

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.12.14",
   "description": "Agentic AI library specialized in LLM Function Calling",
   "engines": {
-    "pnpm": ">=8"
+    "pnpm": ">=10"
   },
   "scripts": {
     "build": "node deploy/build",
@@ -54,5 +54,6 @@
     "overrides": {
       "@types/react": "19.0.0"
     }
-  }
+  },
+  "packageManager": "pnpm@10.6.4"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "pnpm": ">=10"
   },
+  "packageManager": "pnpm@10.6.4",
   "scripts": {
     "build": "node deploy/build",
     "package:latest": "node deploy/publish --tag latest",
@@ -54,6 +55,5 @@
     "overrides": {
       "@types/react": "19.0.0"
     }
-  },
-  "packageManager": "pnpm@10.6.4"
+  }
 }


### PR DESCRIPTION
This pull request includes several changes to update the Node.js and `pnpm` versions used in the project. The most important changes include modifications to the GitHub Actions workflows, updates to the `package.json` file, and the addition of a new `.npmrc` configuration.

Updates to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L13-L18): Removed the `node-version` and `pnpm` version specifications.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-L20): Removed the `node-version` and `pnpm` version specifications.
* [`.github/workflows/website.yml`](diffhunk://#diff-c7731b29de71fca225e1dfac88ebe31975a4cd9759ab13e91d86eeadafbddc10L23-L27): Removed the `node-version` and `pnpm` version specifications.

Updates to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R7): Updated the `pnpm` version requirement to `>=10` and added the `packageManager` field specifying `pnpm@10.6.4`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L57-R58)

Addition of `.npmrc` configuration:

* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1-R2): Added `engine-strict=true` and specified `use-node-version=22.14.0`.