### PR TITLE
revert(create-agentica): revert empty build scripts

### DIFF
--- a/packages/create-agentica/package.json
+++ b/packages/create-agentica/package.json
@@ -6,6 +6,9 @@
   "bin": "./index.js",
   "author": "Wrtn Technologies",
   "license": "MIT",
+  "scripts": {
+    "build": " "
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/wrtnlabs/agentica"


### PR DESCRIPTION
```
Done in 3.7s using pnpm v10.6.4
 ERR_PNPM_NO_SCRIPT  Missing script: build

But script matched with build is present in the root of the workspace,
so you may run "pnpm -w run build"
node:child_process:966
    throw err;
    ^

Error: Command failed: pnpm run build
    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at checkExecSyncError (node:child_process:891:11)
    at Object.execSync (node:child_process:963:15)
    at execute (/home/runner/work/agentica/agentica/deploy/publish.js:14:8)
    at build (/home/runner/work/agentica/agentica/deploy/publish.js:19:3)
    at /home/runner/work/agentica/agentica/deploy/publish.js:82:5
    at Array.forEach (<anonymous>)
    at main (/home/runner/work/agentica/agentica/deploy/publish.js:81:18)
    at Object.<anonymous> (/home/runner/work/agentica/agentica/deploy/publish.js:89:1) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 2925,
  stdout: null,
  stderr: null
}

Node.js v20.19.0
```

It would be better to update where the publish script is modified.


