### PR TITLE
feat(cli): add NestJS + React Template CLI Logic

### DIFF
--- a/packages/cli/src/executable/AgenticaStart.ts
+++ b/packages/cli/src/executable/AgenticaStart.ts
@@ -57,21 +57,23 @@ export namespace AgenticaStart {
     const validAnswers = typia.assert(config);
     const { packageManager, openAIKey, projectType, services } = validAnswers;
 
-    await AgenticaStarter.execute(projectType)({
+    const { projectPaths } = await AgenticaStarter.execute(projectType)({
       projectName,
       projectPath,
       openAIKey,
       services,
     });
 
-    process.chdir(projectPath);
-
     // Run package installation
     console.log("📦 Package installation in progress...");
 
-    Package.installPackage(packageManager)({
-      projectPath,
-      services,
+    projectPaths.forEach((p) => {
+      process.chdir(p);
+
+      Package.installPackage(packageManager)({
+        projectPath: p,
+        services,
+      });
     });
 
     console.log(`\n🎉 Project ${projectName} created`);

--- a/packages/cli/src/functional/AgenticaStarter.ts
+++ b/packages/cli/src/functional/AgenticaStarter.ts
@@ -21,19 +21,26 @@ export namespace AgenticaStarter {
     standalone: {
       title: `Standalone ${blueBright("Application")}`,
       key: "standalone",
-      runner: async (input: IAgenticaStartOption.IProject): Promise<void> =>
-        bootstrap("standalone")(input)(async () => {
+      runner: async (
+        input: IAgenticaStartOption.IProject,
+      ): Promise<{ projectPaths: string[] }> => {
+        await bootstrap("standalone")(input)(async () => {
           const indexFilePath = path.join(input.projectPath, "src/index.ts");
           const indexFileContent = await fs.readFile(indexFilePath, "utf-8");
           return { indexFilePath, indexFileContent };
-        }),
+        });
+
+        return { projectPaths: [input.projectPath] };
+      },
     },
 
     nodejs: {
       title: `NodeJS ${blueBright("Agent Server")}`,
       key: "nodejs",
-      runner: async (input: IAgenticaStartOption.IProject): Promise<void> =>
-        bootstrap("nodejs")(input)(async () => {
+      runner: async (
+        input: IAgenticaStartOption.IProject,
+      ): Promise<{ projectPaths: string[] }> => {
+        await bootstrap("nodejs")(input)(async () => {
           // Modify index.ts: replace import and controller code
           const indexFilePath = path.join(input.projectPath, "src/index.ts");
           const indexFileContent = await fs
@@ -51,13 +58,18 @@ export namespace AgenticaStarter {
             });
 
           return { indexFilePath, indexFileContent };
-        }),
+        });
+
+        return { projectPaths: [input.projectPath] };
+      },
     },
     nestjs: {
       title: `NestJS ${blueBright("Agent Server")}`,
       key: "nestjs",
-      runner: async (input: IAgenticaStartOption.IProject): Promise<void> =>
-        bootstrap("nestjs")(input)(async () => {
+      runner: async (
+        input: IAgenticaStartOption.IProject,
+      ): Promise<{ projectPaths: string[] }> => {
+        await bootstrap("nestjs")(input)(async () => {
           const indexFilePath = path.join(
             input.projectPath,
             "src/controllers/chat/ChatController.ts",
@@ -65,13 +77,51 @@ export namespace AgenticaStarter {
 
           const indexFileContent = await fs.readFile(indexFilePath, "utf-8");
           return { indexFilePath, indexFileContent };
-        }),
+        });
+
+        return { projectPaths: [input.projectPath] };
+      },
     },
     react: {
       title: `React ${blueBright("Client Application")}`,
       key: "react",
-      runner: async (input: IAgenticaStartOption.IProject): Promise<void> => {
+      runner: async (
+        input: IAgenticaStartOption.IProject,
+      ): Promise<{ projectPaths: string[] }> => {
         await writeTemplate("react", input.projectName);
+
+        return { projectPaths: [input.projectPath] };
+      },
+    },
+    "nestjs+react": {
+      title: `NestJS + React ${blueBright("Agent Server + Client Application")}`,
+      key: "nestjs+react",
+      runner: async (
+        input: IAgenticaStartOption.IProject,
+      ): Promise<{ projectPaths: string[] }> => {
+        await bootstrap("nestjs")({
+          ...input,
+          projectPath: `${input.projectPath}/server`,
+          projectName: `${input.projectName}/server`,
+        })(async () => {
+          const indexFilePath = path.join(
+            input.projectPath,
+            "server",
+            "src/controllers/chat/ChatController.ts",
+          );
+
+          const indexFileContent = await fs.readFile(indexFilePath, "utf-8");
+          return { indexFilePath, indexFileContent };
+        });
+
+        await writeTemplate("react", `${input.projectName}/client`);
+
+        return {
+          projectPaths: [
+            `${input.projectPath}/server`,
+            `${input.projectPath}/client`,
+          ],
+        };
       },
     },
   } as const;

--- a/packages/cli/src/functional/AgenticaStarter.ts
+++ b/packages/cli/src/functional/AgenticaStarter.ts
@@ -185,9 +185,17 @@ export namespace AgenticaStarter {
     input: IAgenticaStartOption.IProject,
   ): Promise<void> => {
     // Create .env file
-    const envContent = `OPENAI_API_KEY=${input.openAIKey}\n`;
-    await fs.writeFile(path.join(input.projectPath, ".env"), envContent);
-    console.log("✅ .env created");
+    const envPath = path.join(input.projectPath, ".env");
+    const envContent = `\nOPENAI_API_KEY=${input.openAIKey}\n`;
+
+    try {
+      await fs.access(envPath);
+      await fs.appendFile(envPath, envContent);
+      console.log("✅ .env updated");
+    } catch (err) {
+      await fs.writeFile(envPath, envContent);
+      console.log("✅ .env created");
+    }
   };
   /**
    * Git Clone from template repository.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 
 import { AgenticaStart } from "./executable/AgenticaStart";
 import { IAgenticaStart } from "./structures/IAgenticaStart";
-import { redBright, blueBright } from './utils/styleText';
+import { blueBright, redBright } from "./utils/styleText";
 
 async function main() {
   const program = new Command();
@@ -11,7 +11,7 @@ async function main() {
     .command("start <directory>")
     .description("Start a new project")
     .option(
-      "-p, --project [nodejs|nestjs|react|standalone]",
+      "-p, --project [nodejs|nestjs|react|nestjs+react|standalone]",
       "The project type",
     )
     .action(async (directory: string, options: IAgenticaStart.IOptions) => {

--- a/packages/cli/src/utils/types/ProjectOption.ts
+++ b/packages/cli/src/utils/types/ProjectOption.ts
@@ -1,4 +1,9 @@
 /**
  * Value of the `--project` option.
  */
-export type ProjectOptionValue = "nodejs" | "nestjs" | "react" | "standalone";
+export type ProjectOptionValue =
+  | "nodejs"
+  | "nestjs"
+  | "react"
+  | "standalone"
+  | "nestjs+react";


### PR DESCRIPTION
## Description
- We need a unified template that combines NestJS and React for usability. so added Agentica CLI logic to install React and NestJS at once.

## Task
**Added NestJS + React project option**
- `src/index.ts` : add `nestjs+react` option.
- `src/utils/types/ProjectOption.ts` : add `nestjs+react` union value.
- `src/functional/AgenticaStarter.ts` : fix the `runner` function to return the projectPaths to install packages for each directory.
- `src/functional/AgenticaStart.ts` : fix the `AgenticaStarter.execute` logic to install packages for each directory.

** Modified setEnvFiles function**
- `src/functional/AgenticaStarter.ts` : Added if branches to ensure that the `.env` files created for each `ProjectOptionValue` are all different.