### PR TITLE
feat(ci): improve release workflow automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 # author: elliot-huffman
 name: release
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "*"
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -23,3 +25,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}
           NPM_CONFIG_PROVENANCE: true # Enable provenance
 
+  release:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - run: pnpm dlx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Change release workflow to trigger on tag push instead of release creation. Add automatic GitHub release creation with changelogithub after successful npm publish.

So the release flow changes.

When you want to release new package,
```sh
cd (git root)
pnpm i
pnpm release
```

Then, then versions in package.json are updated and git tags are created automatically
When tag is pushed, GH Actions publish packages to npm, and create release automatically!