### PR TITLE
feat: check lint on push

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,5 +1,6 @@
 name: lint-check
 on:
+  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,5 +1,6 @@
 name: spell-check
 on:
+  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
because this repository is public, we can use github actions without limits.
Also sometimes people push commits on main, which doesn't makes CI run.
This PR makes CI run on every push/pr