### PR TITLE
fix(ci): split test and publish-build-dry-run

### DIFF
--- a/.github/workflows/build-and-publish-dry-run.yml
+++ b/.github/workflows/build-and-publish-dry-run.yml
@@ -1,25 +1,10 @@
-name: build
+name: build and publish dry run
 on:
+  push:
   pull_request:
-    paths:
-      - 'packages/*/src/**'
-      - 'test/**'
-      - 'package.json'
-jobs:
-  Test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Test
-        run: pnpm start
-        working-directory: ./test
-        env:
-          CHATGPT_API_KEY: ${{ secrets.CHATGPT_API_KEY }}
 
-  Publish-dry-run:
+jobs:
+  build-and-publish-dry-run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: test
+on:
+  pull_request:
+    paths:
+      - 'packages/*/src/**'
+      - 'test/**'
+      - 'package.json'
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Test
+        run: pnpm start
+        working-directory: ./test
+        env:
+          CHATGPT_API_KEY: ${{ secrets.CHATGPT_API_KEY }}
+


### PR DESCRIPTION
we split build-pulblish-dry-run and test in different filees.
We use chatgpt api so e2e should be only on pull_request.
However, we can run build and upload it to pkg.pr.new everytime without worrying about any cost!