### PR TITLE
chore(*): introduce typos vscode extenstions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "tekumara.typos-vscode"
   ]
 }


### PR DESCRIPTION
introduce typos vscode extenions 

this exteions is https://github.com/crate-ci/typos/ wrapper


---

As I understand it, it also plays the role of prettier in the eslint setup.
Is prettier deprecated now?

---

This pull request includes a small change to the `.vscode/extensions.json` file. The change adds a new recommended extension for VS Code, `tekumara.typos-vscode`, to the existing list of recommendations.