### PR TITLE
feat: add aggregate-output flag to lint commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "package:next": "pnpm --filter='./packages/**' -r publish --tag next",
     "preinstall": "npx only-allow pnpm",
     "release": "bumpp",
-    "lint": "pnpm --no-bail /^lint:/",
+    "lint": "pnpm --no-bail --aggregate-output /^lint:/",
     "lint:root": "eslint .",
-    "lint:submodules": "pnpm --parallel -r --no-bail /^lint/",
+    "lint:submodules": "pnpm --parallel -r --no-bail --aggregate-output /^lint/",
     "format": "pnpm --aggregate-output /^format:/",
     "format:root": "eslint . --fix",
     "format:submodules": "pnpm --parallel -r --aggregate-output /^format/"


### PR DESCRIPTION
Improves the readability of the lint command output by using PNPM's aggregate-output flag which groups outputs from multiple commands together.
As @sunrabbit123 added it to format commands in #205 