### PR TITLE
Dark mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Check out the document in the [website](https://wrtnlabs.io/agentica):
 - [📦 Setup](https://wrtnlabs.io/agentica/docs/setup)
 - 🔍 Concepts
   - [Function Calling](https://wrtnlabs.io/agentica/docs/concepts/function-calling)
-  - [Document Driven Development](https://wrtnlabs.io/agentica/docs/concepts/document-driven-development)
   - [Compiler Driven Development](https://wrtnlabs.io/agentica/docs/concepts/compiler-driven-development)
+  - [Document Driven Development](https://wrtnlabs.io/agentica/docs/concepts/document-driven-development)
 
 ### 📖 Features
 - **📚 Core Library**

--- a/website/app/layout.jsx
+++ b/website/app/layout.jsx
@@ -34,10 +34,10 @@ export default async function RootLayout(props) {
       suppressHydrationWarning
     >
       <Head
-        backgroundColor={{
-          dark: "rgb(9, 15, 27)",
-          light: "rgb(250, 250, 250)",
-        }}
+        // backgroundColor={{
+        //   dark: "rgb(9, 15, 27)",
+        //   light: "rgb(250, 250, 250)",
+        // }}
         // color={{
         //   hue: { dark: 120, light: 0 },
         //   saturation: { dark: 100, light: 100 },
@@ -111,6 +111,7 @@ export default async function RootLayout(props) {
           nextThemes={{
             defaultTheme: "dark",
           }}
+          darkMode={false}
           // ...Your additional theme config options
         >
           {props.children}

--- a/website/content/docs/concepts/_meta.ts
+++ b/website/content/docs/concepts/_meta.ts
@@ -2,7 +2,7 @@ import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
   "function-calling": "Function Calling",
-  "document-driven-development": "Document Driven Dev.",
   "compiler-driven-development": "Compiler Driven Dev.",
+  "document-driven-development": "Document Driven Dev.",
 };
 export default meta;

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -13,7 +13,4 @@ export default withNextra({
   images: {
     unoptimized: true,
   },
-  nextThemes: {
-    theme: "dark",
-  },
 });


### PR DESCRIPTION
This pull request includes several changes to the `website` and `README.md` files to update documentation links, modify layout configurations, and adjust theme settings.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R59): Corrected the order of the "Document Driven Development" link in the concepts section.
* [`website/content/docs/concepts/_meta.ts`](diffhunk://#diff-d363de1c397f359217ce2e3450971dd9b62d590266024c06ac235352f315a54aL5-R6): Ensured consistent naming for "Document Driven Development" in the meta records.

Layout and theme adjustments:

* [`website/app/layout.jsx`](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99L37-R40): Commented out the background color settings to potentially simplify the layout configuration.
* [`website/app/layout.jsx`](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99R114): Added a `darkMode` property set to `false` in the theme configuration.
* [`website/next.config.ts`](diffhunk://#diff-fb5d281398dc89dbf8c238d09e6c1a8db1475f4fef749e6e48d62948caf277cfL16-L18): Removed the `nextThemes` configuration to streamline the theme settings.