### PR TITLE
docs(website): fix google scholar tutorial 

### DIFF
--- a/website/content/tutorial/productivity/google-scholar.mdx
+++ b/website/content/tutorial/productivity/google-scholar.mdx
@@ -1,3 +1,7 @@
+---
+title: Agentica > Tutorial > Google Scholar Agents
+---
+
 ## Quick CLI Setup
 
 ## Introduction


### PR DESCRIPTION
This pull request includes a small change to the `website/content/tutorial/productivity/google-scholar.mdx` file. The change adds a title to the Google Scholar Agents tutorial.

* [`website/content/tutorial/productivity/google-scholar.mdx`](diffhunk://#diff-def6ec037c5acde0f5bb6038b0fd7cb72a5751c2557cc7843bba032ed0a7d0d4R1-R4): Added a title to the Google Scholar Agents tutorial.