### PR TITLE
feat(cli): add version support to command line interface

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,1 +1,3 @@
 .tmp/
+!bin
+dist

--- a/packages/cli/bin/index.mjs
+++ b/packages/cli/bin/index.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { run } from '../dist/index.mjs';
+run();

--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -3,7 +3,7 @@ import { defineBuildConfig } from "unbuild";
 import pkgJson from "./package.json";
 
 export default defineBuildConfig({
-  outDir: "bin",
+  outDir: "dist",
   entries: ["src/index.ts"],
   declaration: false,
   clean: true,
@@ -18,9 +18,6 @@ export default defineBuildConfig({
   },
   rollup: {
     inlineDependencies: true,
-    output: {
-      banner: "#!/usr/bin/env node",
-    },
     esbuild: {
       minify: true,
     },

--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -1,5 +1,6 @@
 import UnpluginTypia from "@ryoppippi/unplugin-typia/vite";
 import { defineBuildConfig } from "unbuild";
+import pkgJson from "./package.json";
 
 export default defineBuildConfig({
   outDir: "bin",
@@ -11,6 +12,9 @@ export default defineBuildConfig({
       // plugin should be added to the first
       options.plugins.unshift(UnpluginTypia());
     },
+  },
+  replace: {
+    "process.env.AGENTICA_VERSION": JSON.stringify(pkgJson.version), // replace version from package.json on build
   },
   rollup: {
     inlineDependencies: true,

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,37 @@
+afterEach(() => {
+  // reset the modules to avoid import cache
+  vi.resetModules();
+
+  // unstub all the environment variables
+  vi.unstubAllEnvs();
+});
+
+describe("cli", () => {
+  describe("version", () => {
+    it("should return 0.0.0 as version when AGENTICA_VERSION is not set", async () => {
+      const { program } = await import("./index");
+
+      // override output to avoid the process to exit
+      program.exitOverride().action(() => {});
+
+      // using the exit override to capture the version output
+      expect(() => {
+        program.parse(["node", "agentica", "--version"]);
+      }).toThrow("0.0.0");
+    });
+
+    it("should return the version from AGENTICA_VERSION", async () => {
+      // stub the environment variable
+      vi.stubEnv("AGENTICA_VERSION", "1.2.3");
+
+      const { program } = await import("./index");
+
+      // override output to avoid the process to exit
+      program.exitOverride().action(() => {});
+
+      expect(() => {
+        program.parse(["node", "agentica", "--version"]);
+      }).toThrow("1.2.3");
+    });
+  });
+});

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -34,4 +34,9 @@ describe("cli", () => {
       }).toThrow("1.2.3");
     });
   });
+
+  describe("start", () => {
+    it.todo("test the start command with no project option");
+    it.todo("should show an error when the project option is invalid");
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import type { StarterTemplate } from "./commands/start";
 
 import process from "node:process";
 import * as p from "@clack/prompts";
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import * as picocolors from "picocolors";
 import typia from "typia";
 import { start } from "./commands";
@@ -20,8 +20,7 @@ const VERSION = process.env.AGENTICA_VERSION ?? "0.0.0";
 const program = new Command();
 
 program
-  .version(VERSION)
-  .addOption(new Option("-v, --secretVersion").hideHelp());
+  .version(VERSION);
 
 // TODO: project option should be template
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import type { StarterTemplate } from "./commands/start";
 
 import process from "node:process";
 import * as p from "@clack/prompts";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import * as picocolors from "picocolors";
 import typia from "typia";
 import { start } from "./commands";
@@ -22,6 +22,7 @@ const program = new Command();
 // TODO: project option should be template
 program
   .version(VERSION)
+  .addOption(new Option("-v, --secretVersion").hideHelp())
   .command("start")
   .description("Start a new project")
   .option(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,10 +19,12 @@ const VERSION = process.env.AGENTICA_VERSION ?? "0.0.0";
 
 const program = new Command();
 
-// TODO: project option should be template
 program
   .version(VERSION)
-  .addOption(new Option("-v, --secretVersion").hideHelp())
+  .addOption(new Option("-v, --secretVersion").hideHelp());
+
+// TODO: project option should be template
+program
   .command("start")
   .description("Start a new project")
   .option(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,3 +53,5 @@ program
   });
 
 program.parse(process.argv);
+
+export { program };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,10 +11,17 @@ interface CliOptions {
   project?: StarterTemplate;
 }
 
+/**
+ * The version of the Agentica CLI
+ * in production, it will be replaced by unbuild
+ */
+const VERSION = process.env.AGENTICA_VERSION ?? "0.0.0";
+
 const program = new Command();
 
 // TODO: project option should be template
 program
+  .version(VERSION)
   .command("start")
   .description("Start a new project")
   .option(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,11 @@ program
     await start({ template: options.project });
   });
 
-program.parse(process.argv);
+/**
+ * Run the program
+ */
+export function run() {
+  program.parse(process.argv);
+}
 
 export { program };

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -45,7 +45,7 @@
     "downlevelIteration": true, /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     "newLine": "LF",
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./bin", /* Redirect output structure to the directory. */
+    "outDir": "./dist", /* Redirect output structure to the directory. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true, /* Generates corresponding '.map' file. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/packages/create-agentica/index.js
+++ b/packages/create-agentica/index.js
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
+import { run } from 'agentica';
 
-import('agentica')
+await run();


### PR DESCRIPTION
you can check it with `pnpm run node ./bin/index.mjs --version`

Implement version support in the CLI tool by:
- Importing package.json version in build config
- Adding environment variable replacement during build
- Setting up version command in the CLI program

This allows users to check the CLI version with --version flag.




This pull request includes changes to the `packages/cli` to integrate the version from `package.json` into the build process and CLI version display. The most important changes include importing the `package.json` file, adding a replace configuration for the version, and defining the version constant in the CLI source code.

### Integration of version from `package.json`:

* [`packages/cli/build.config.ts`](diffhunk://#diff-9a7382d3037f737c8c0654204114d28ce916c4944d7dd8608f19cf27f63b73e0R3): Imported `package.json` to access the version information.
* [`packages/cli/build.config.ts`](diffhunk://#diff-9a7382d3037f737c8c0654204114d28ce916c4944d7dd8608f19cf27f63b73e0R16-R18): Added a replace configuration to substitute `process.env.AGENTICA_VERSION` with the version from `package.json` during the build process.
* [`packages/cli/src/index.ts`](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR14-R24): Defined a `VERSION` constant using `process.env.AGENTICA_VERSION` and set a default value of "0.0.0" if the environment variable is not set.
* [`packages/cli/src/index.ts`](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR14-R24): Updated the CLI program to use the `VERSION` constant for displaying the version.