### PR TITLE
fix(cli): UnpluginTypia sholud be a rollup plugin

### DIFF
--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -1,4 +1,4 @@
-import UnpluginTypia from "@ryoppippi/unplugin-typia/vite";
+import UnpluginTypia from "@ryoppippi/unplugin-typia/rollup";
 import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({


### PR DESCRIPTION
Change the import path for UnpluginTypia to use the rollup version instead of the vite version in the CLI build configuration.