### PR TITLE
feat(pg-vector-selector): remove namespace

### DIFF
--- a/packages/pg-vector-selector/src/AgenticaPgVectorSelector.ts
+++ b/packages/pg-vector-selector/src/AgenticaPgVectorSelector.ts
@@ -71,109 +71,159 @@ function groupByArray<T>(array: T[], count: number): T[][] {
 
 const retry = getRetry(3);
 
-export namespace AgenticaPgVectorSelector {
-  export function boot<SchemaModel extends ILlmSchema.Model>(props: IAgenticaPgVectorSelectorBootProps) {
-    const [isEmbeddedContext, setEmbeddedContext, getFilterFromContext]
+export function boot<SchemaModel extends ILlmSchema.Model>(props: IAgenticaPgVectorSelectorBootProps) {
+  const [isEmbeddedContext, setEmbeddedContext, getFilterFromContext]
       = useEmbeddedContext<SchemaModel>();
-    const connection = props.connectorHiveConnection;
-    const embedOperation = async (
-      controllerName: string,
-      opList: AgenticaOperation<SchemaModel>[],
-    ) => {
-      const application = await retry(async () =>
-        functional.applications.create(connection, {
-          name: controllerName,
-          description: undefined,
-        }),
-      ).catch(async (e) => {
-        if (!(e instanceof HttpError)) {
-          throw e;
-        }
-        if (e.status !== 409) {
-          throw e;
-        }
-
-        return retry(async () =>
-          functional.applications.by_names.getByName(
-            connection,
-            controllerName,
-          ),
-        );
-      });
-
-      const version = await retry(async () =>
-        functional.applications.by_ids.versions.create(
-          connection,
-          application.id,
-          {},
-        ),
-      );
-
-      // concurrency request count
-      await groupByArray(opList, 10).reduce(async (accPromise, cur) => {
-        await accPromise;
-        await Promise.all(
-          cur.map(async v =>
-            retry(async () =>
-              functional.application_versions.by_ids.connectors.create(
-                connection,
-                version.id,
-                { name: v.name, description: v.function.description ?? "" },
-              ),
-            ),
-          ),
-        );
-        return Promise.resolve();
-      }, Promise.resolve());
-
-      return { version, applicationId: application.id };
-    };
-
-    const embedContext = async (ctx: AgenticaContext<SchemaModel>) => {
-      const filter = await Promise.all(
-        Array.from(ctx.operations.group.entries()).map(
-          async ([key, value]: [
-            string,
-            Map<string, AgenticaOperation<SchemaModel>>,
-          ]) => {
-            const result = await embedOperation(
-              key,
-              Array.from(value.values()),
-            );
-
-            return {
-              id: result.applicationId,
-              version: result.version.version,
-              type: "byId",
-            } satisfies IApplicationConnectorRetrieval.IFilterApplicationById;
-          },
-        ),
-      );
-
-      setEmbeddedContext(ctx, {
-        applications: filter,
-      });
-    };
-
-    const selectorExecute = async (
-      ctx: AgenticaContext<SchemaModel>,
-    ): Promise<AgenticaPrompt<SchemaModel>[]> => {
-      if (!isEmbeddedContext(ctx)) {
-        await embedContext(ctx);
+  const connection = props.connectorHiveConnection;
+  const embedOperation = async (
+    controllerName: string,
+    opList: AgenticaOperation<SchemaModel>[],
+  ) => {
+    const application = await retry(async () =>
+      functional.applications.create(connection, {
+        name: controllerName,
+        description: undefined,
+      }),
+    ).catch(async (e) => {
+      if (!(e instanceof HttpError)) {
+        throw e;
+      }
+      if (e.status !== 409) {
+        throw e;
       }
 
-      const prompts: AgenticaPrompt<SchemaModel>[] = [];
+      return retry(async () =>
+        functional.applications.by_names.getByName(
+          connection,
+          controllerName,
+        ),
+      );
+    });
 
-      const filter = getFilterFromContext(ctx);
+    const version = await retry(async () =>
+      functional.applications.by_ids.versions.create(
+        connection,
+        application.id,
+        {},
+      ),
+    );
 
-      const completionStream = await ctx.request("select", {
+    // concurrency request count
+    await groupByArray(opList, 10).reduce(async (accPromise, cur) => {
+      await accPromise;
+      await Promise.all(
+        cur.map(async v =>
+          retry(async () =>
+            functional.application_versions.by_ids.connectors.create(
+              connection,
+              version.id,
+              { name: v.name, description: v.function.description ?? "" },
+            ),
+          ),
+        ),
+      );
+      return Promise.resolve();
+    }, Promise.resolve());
+
+    return { version, applicationId: application.id };
+  };
+
+  const embedContext = async (ctx: AgenticaContext<SchemaModel>) => {
+    const filter = await Promise.all(
+      Array.from(ctx.operations.group.entries()).map(
+        async ([key, value]: [
+          string,
+          Map<string, AgenticaOperation<SchemaModel>>,
+        ]) => {
+          const result = await embedOperation(
+            key,
+            Array.from(value.values()),
+          );
+
+          return {
+            id: result.applicationId,
+            version: result.version.version,
+            type: "byId",
+          } satisfies IApplicationConnectorRetrieval.IFilterApplicationById;
+        },
+      ),
+    );
+
+    setEmbeddedContext(ctx, {
+      applications: filter,
+    });
+  };
+
+  const selectorExecute = async (
+    ctx: AgenticaContext<SchemaModel>,
+  ): Promise<AgenticaPrompt<SchemaModel>[]> => {
+    if (!isEmbeddedContext(ctx)) {
+      await embedContext(ctx);
+    }
+
+    const prompts: AgenticaPrompt<SchemaModel>[] = [];
+
+    const filter = getFilterFromContext(ctx);
+
+    const completionStream = await ctx.request("select", {
+      messages: [
+        {
+          role: "developer",
+          content: [
+            "you are a function searcher, you will extract search query from user message",
+            "the query like vector search query and query result is function name",
+            "so the extracted query must be for function search",
+          ].join("\n"),
+        },
+        ...ctx.histories
+          .map(ChatGptHistoryDecoder.decode<SchemaModel>)
+          .flat(),
+        {
+          role: "user",
+          content: ctx.prompt.text,
+        },
+      ],
+      tool_choice: "required",
+
+      tools: [Tools.extract_query],
+    });
+
+    const chunks = await StreamUtil.readAll(completionStream);
+    const completion = ChatGptCompletionMessageUtil.merge(chunks);
+
+    const resultList = await Promise.all(
+      completion.choices[0]?.message.tool_calls?.flatMap(async (v) => {
+        const arg = JSON.parse(v.function.arguments) as { query?: string };
+        const query = arg.query;
+        if (typeof query !== "string") {
+          return [];
+        }
+        return retry(async () =>
+          functional.connector_retrievals.createRetrievalRequest(connection, {
+            query,
+            limit: 10,
+            filter,
+          }),
+        );
+      }) ?? [],
+    ).then(res =>
+      res.flatMap(output =>
+        output.map(v => ({
+          name: v.name,
+          description: v.description,
+        })),
+      ),
+    );
+
+    const selectCompletion = await ctx
+      .request("select", {
         messages: [
           {
             role: "developer",
             content: [
-              "you are a function searcher, you will extract search query from user message",
-              "the query like vector search query and query result is function name",
-              "so the extracted query must be for function search",
+              props.experimental?.select_prompt
+              ?? "You are an AI assistant that selects and executes the most appropriate function(s) based on the current context, running the functions required by the context in the correct order. First, analyze the user's input or situation and provide a brief reasoning for why you chose the function(s) (one or more). Then, execute the selected function(s). If multiple functions are chosen, the order of execution follows the function call sequence, and the result may vary depending on this order. Return the results directly after execution. If clarification is needed, ask the user a concise question.",
+              `<FUNCTION_LIST>${JSON.stringify(resultList)}</FUNCTION_LIST>`,
             ].join("\n"),
           },
           ...ctx.histories
@@ -185,102 +235,50 @@ export namespace AgenticaPgVectorSelector {
           },
         ],
         tool_choice: "required",
+        tools: [Tools.execute_function],
+      })
+      .then(async v => StreamUtil.readAll(v))
+      .then(ChatGptCompletionMessageUtil.merge);
 
-        tools: [Tools.extract_query],
-      });
+    selectCompletion.choices
+      .filter(v => v.message.tool_calls != null)
+      .forEach((v) => {
+        v.message
+          .tool_calls!.filter(tc => tc.function.name === "execute_function").forEach((tc) => {
+          const collection = new AgenticaSelectPrompt<SchemaModel>({
+            id: tc.id,
+            selections: [],
+          });
+          const arg = JSON.parse(tc.function.arguments) as {
+            function_name_list: {
+              reason: string;
+              function_name: string;
+            }[];
+          };
 
-      const chunks = await StreamUtil.readAll(completionStream);
-      const completion = ChatGptCompletionMessageUtil.merge(chunks);
-
-      const resultList = await Promise.all(
-        completion.choices[0]?.message.tool_calls?.flatMap(async (v) => {
-          const arg = JSON.parse(v.function.arguments) as { query?: string };
-          const query = arg.query;
-          if (typeof query !== "string") {
-            return [];
-          }
-          return retry(async () =>
-            functional.connector_retrievals.createRetrievalRequest(connection, {
-              query,
-              limit: 10,
-              filter,
-            }),
-          );
-        }) ?? [],
-      ).then(res =>
-        res.flatMap(output =>
-          output.map(v => ({
-            name: v.name,
-            description: v.description,
-          })),
-        ),
-      );
-
-      const selectCompletion = await ctx
-        .request("select", {
-          messages: [
-            {
-              role: "developer",
-              content: [
-                props.experimental?.select_prompt
-                ?? "You are an AI assistant that selects and executes the most appropriate function(s) based on the current context, running the functions required by the context in the correct order. First, analyze the user's input or situation and provide a brief reasoning for why you chose the function(s) (one or more). Then, execute the selected function(s). If multiple functions are chosen, the order of execution follows the function call sequence, and the result may vary depending on this order. Return the results directly after execution. If clarification is needed, ask the user a concise question.",
-                `<FUNCTION_LIST>${JSON.stringify(resultList)}</FUNCTION_LIST>`,
-              ].join("\n"),
-            },
-            ...ctx.histories
-              .map(ChatGptHistoryDecoder.decode<SchemaModel>)
-              .flat(),
-            {
-              role: "user",
-              content: ctx.prompt.text,
-            },
-          ],
-          tool_choice: "required",
-          tools: [Tools.execute_function],
-        })
-        .then(async v => StreamUtil.readAll(v))
-        .then(ChatGptCompletionMessageUtil.merge);
-
-      selectCompletion.choices
-        .filter(v => v.message.tool_calls != null)
-        .forEach((v) => {
-          v.message
-            .tool_calls!.filter(tc => tc.function.name === "execute_function").forEach((tc) => {
-            const collection = new AgenticaSelectPrompt<SchemaModel>({
-              id: tc.id,
-              selections: [],
-            });
-            const arg = JSON.parse(tc.function.arguments) as {
-              function_name_list: {
-                reason: string;
-                function_name: string;
-              }[];
-            };
-
-            arg.function_name_list.forEach((fn) => {
-              const operation = ctx.operations.flat.get(fn.function_name);
-              if (operation === undefined) {
-                return;
-              }
-              const selection: AgenticaOperationSelection<SchemaModel>
+          arg.function_name_list.forEach((fn) => {
+            const operation = ctx.operations.flat.get(fn.function_name);
+            if (operation === undefined) {
+              return;
+            }
+            const selection: AgenticaOperationSelection<SchemaModel>
                   = new AgenticaOperationSelection({
                     reason: fn.reason,
                     operation,
                   });
-              ctx.stack.push(selection);
-              void ctx.dispatch(new AgenticaSelectEvent({ selection }));
-              collection.selections.push(selection);
-            });
-
-            if (collection.selections.length !== 0) {
-              prompts.push(collection);
-            }
+            ctx.stack.push(selection);
+            void ctx.dispatch(new AgenticaSelectEvent({ selection }));
+            collection.selections.push(selection);
           });
+
+          if (collection.selections.length !== 0) {
+            prompts.push(collection);
+          }
         });
+      });
 
-      return prompts;
-    };
+    return prompts;
+  };
 
-    return selectorExecute;
-  }
+  return selectorExecute;
 }

--- a/packages/pg-vector-selector/src/index.ts
+++ b/packages/pg-vector-selector/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./AgenticaPgVectorSelector";
+export * as AgenticaPgVectorSelector from "./AgenticaPgVectorSelector";
 export * from "./AgenticaPgVectorSelectorBootProps";


### PR DESCRIPTION
This pull request includes changes to the `packages/pg-vector-selector` to improve the structure and usage of the `AgenticaPgVectorSelector` namespace. The most important changes include modifying the export statements and the structure of the namespace.

Namespace and export modifications:

* [`packages/pg-vector-selector/src/AgenticaPgVectorSelector.ts`](diffhunk://#diff-253fab8a8e7cdc9a558701d95d614c76132bbe5f7a642a47cfff07a5a02cd068L74): Removed the `export namespace AgenticaPgVectorSelector` declaration and adjusted the function definitions accordingly. [[1]](diffhunk://#diff-253fab8a8e7cdc9a558701d95d614c76132bbe5f7a642a47cfff07a5a02cd068L74) [[2]](diffhunk://#diff-253fab8a8e7cdc9a558701d95d614c76132bbe5f7a642a47cfff07a5a02cd068L286)
* [`packages/pg-vector-selector/src/index.ts`](diffhunk://#diff-8ae2c7246b085e7eb7cd9a4a88facf7b072ccd02d682018b04da146c30df30f4L1-R1): Changed the export statement to use `export * as AgenticaPgVectorSelector` instead of `export *`.