### PR TITLE
fix(cli): remove BbsArticle when select connectors in NestJS Template

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -267,12 +267,14 @@ export async function setupNodeJSProject({ projectAbsolutePath, context }: Setup
   const connectorsCode = generateConnectorsArrayCode(context.services);
   const indexFilePath = join(projectAbsolutePath, "src/index.ts");
   let indexFileContent = await readFile(indexFilePath, "utf-8");
-  indexFileContent = indexFileContent
-    .replace(/import \{ BbsArticleService \}.*;\n/g, "")
-    .replace(
-      /controllers:\s*\[[\s\S]*?\],\n/,
-      "controllers: [/// INSERT CONTROLLER HERE],\n",
-    );
+  if (context.services.length !== 0) {
+    indexFileContent = indexFileContent
+      .replace(/import \{ BbsArticleService \}.*;\n/g, "")
+      .replace(
+        /controllers:\s*\[[\s\S]*?\],\n/,
+        "controllers: [/// INSERT CONTROLLER HERE],\n",
+      );
+  }
   const updatedIndexFileContent = insertCodeIntoAgenticaStarter({
     content: indexFileContent,
     importCode,
@@ -318,12 +320,14 @@ export async function setupNestJSProject({ projectAbsolutePath, context }: Setup
     "src/controllers/chat/ChatController.ts",
   );
   let indexFileContent = await readFile(indexFilePath, "utf-8");
-  indexFileContent = indexFileContent
-    .replace(/import \{ BbsArticleService \}.*;\n/g, "")
-    .replace(
-      /controllers:\s*\[[\s\S]*?\],\n/,
-      "controllers: [/// INSERT CONTROLLER HERE],\n",
-    );
+  if (context.services.length !== 0) {
+    indexFileContent = indexFileContent
+      .replace(/import \{ BbsArticleService \}.*;\n/g, "")
+      .replace(
+        /controllers:\s*\[[\s\S]*?\],\n/,
+        "controllers: [/// INSERT CONTROLLER HERE],\n",
+      );
+  }
   const updatedIndexFileContent = insertCodeIntoAgenticaStarter({
     content: indexFileContent,
     importCode,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -266,15 +266,16 @@ export async function setupNodeJSProject({ projectAbsolutePath, context }: Setup
   const importCode = generateServiceImportsCode(context.services);
   const connectorsCode = generateConnectorsArrayCode(context.services);
   const indexFilePath = join(projectAbsolutePath, "src/index.ts");
-  let indexFileContent = await readFile(indexFilePath, "utf-8");
-  if (context.services.length !== 0) {
-    indexFileContent = indexFileContent
+  const indexFileContent = await readFile(indexFilePath, "utf-8").then((content) => {
+    if (context.services.length === 0) {
+      return content;
+    }
+
+    return content
       .replace(/import \{ BbsArticleService \}.*;\n/g, "")
-      .replace(
-        /controllers:\s*\[[\s\S]*?\],\n/,
-        "controllers: [/// INSERT CONTROLLER HERE],\n",
-      );
-  }
+      .replace(/controllers:\s*\[[\s\S]*?\],\n/, "controllers: [/// INSERT CONTROLLER HERE],\n");
+  });
+
   const updatedIndexFileContent = insertCodeIntoAgenticaStarter({
     content: indexFileContent,
     importCode,
@@ -319,15 +320,15 @@ export async function setupNestJSProject({ projectAbsolutePath, context }: Setup
     projectAbsolutePath,
     "src/controllers/chat/ChatController.ts",
   );
-  let indexFileContent = await readFile(indexFilePath, "utf-8");
-  if (context.services.length !== 0) {
-    indexFileContent = indexFileContent
+  const indexFileContent = await readFile(indexFilePath, "utf-8").then((content) => {
+    if (context.services.length === 0) {
+      return content;
+    }
+
+    return content
       .replace(/import \{ BbsArticleService \}.*;\n/g, "")
-      .replace(
-        /controllers:\s*\[[\s\S]*?\],\n/,
-        "controllers: [/// INSERT CONTROLLER HERE],\n",
-      );
-  }
+      .replace(/controllers:\s*\[[\s\S]*?\],\n/, "controllers: [/// INSERT CONTROLLER HERE],\n");
+  });
   const updatedIndexFileContent = insertCodeIntoAgenticaStarter({
     content: indexFileContent,
     importCode,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -317,7 +317,13 @@ export async function setupNestJSProject({ projectAbsolutePath, context }: Setup
     projectAbsolutePath,
     "src/controllers/chat/ChatController.ts",
   );
-  const indexFileContent = await readFile(indexFilePath, "utf-8");
+  let indexFileContent = await readFile(indexFilePath, "utf-8");
+  indexFileContent = indexFileContent
+    .replace(/import \{ BbsArticleService \}.*;\n/g, "")
+    .replace(
+      /controllers:\s*\[[\s\S]*?\],\n/,
+      "controllers: [/// INSERT CONTROLLER HERE],\n",
+    );
   const updatedIndexFileContent = insertCodeIntoAgenticaStarter({
     content: indexFileContent,
     importCode,


### PR DESCRIPTION
## Description

currently, when select the connectors on Agentca cli in NestJS Template, The original controller `BbsArticle` is not removed.
so, we need to remove that code.
also It has an error that user doesn't select any connector, BbsArticle is kept in template, but removed.

## What to do
- Add to remove the `BbsArticle`
- Add the logic when user doesn't any connector, keep the BbsArticle in template.