### PR TITLE
fix(website): wrong youtube short url

### DIFF
--- a/website/content/tutorial/productivity/notion.mdx
+++ b/website/content/tutorial/productivity/notion.mdx
@@ -6,7 +6,7 @@ title: Agentica > Tutorial > Notion Agents
 
 <br />
 <iframe
-  src="https://www.youtube.com/shorts/hzkNNt7bvUQ"
+  src="https://www.youtube.com/embed/hzkNNt7bvUQ"
   title="Notion Agent with Agentica"
   width="100%"
   height="600"


### PR DESCRIPTION
This pull request includes a small change to the `website/content/tutorial/productivity/notion.mdx` file. The change updates the YouTube video embed URL format.

* [`website/content/tutorial/productivity/notion.mdx`](diffhunk://#diff-ba819cbcbecfb72ec7460fd8fac1c87eb0d84d36af2110eabe64d7cdae400a9eL9-R9): Changed the `src` attribute of the `iframe` element from `https://www.youtube.com/shorts/hzkNNt7bvUQ` to `https://www.youtube.com/embed/hzkNNt7bvUQ`.