### PR TITLE
fix(core): replace uuid package with node:crypto

### DIFF
--- a/packages/chat/src/examples/bbs/BbsArticleService.ts
+++ b/packages/chat/src/examples/bbs/BbsArticleService.ts
@@ -1,5 +1,5 @@
 import { tags } from "typia";
-import { v4 } from "uuid";
+import { randomUUID } from 'node:crypto';
 
 import { IBbsArticle } from "./IBbsArticle";
 
@@ -32,7 +32,7 @@ export class BbsArticleService {
     input: IBbsArticle.ICreate;
   }): IBbsArticle {
     const article: IBbsArticle = {
-      id: v4(),
+      id: randomUUID(),
       title: props.input.title,
       body: props.input.body,
       thumbnail: props.input.thumbnail,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,8 +54,7 @@
   },
   "dependencies": {
     "@samchon/openapi": "^3.2.0",
-    "typia": "^8.0.4",
-    "uuid": "^11.0.4"
+    "typia": "^8.0.4"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.8.2",


### PR DESCRIPTION
Use Node.js built-in randomUUID() from the crypto module instead of the external uuid package. This reduces dependencies and leverages native functionality.

This pull request includes changes to the `BbsArticleService` to update the UUID generation method and to the `package.json` file to remove an unused dependency.

UUID generation update:

* [`packages/chat/src/examples/bbs/BbsArticleService.ts`](diffhunk://#diff-f3b31a0f9dde174119f8a6e708d5756e9351c19b0af5aa52ddbd2ee687f1dd4aL2-R2): Replaced the `uuid` library with the built-in `crypto` module for generating UUIDs. The `v4` method was replaced with `randomUUID`. [[1]](diffhunk://#diff-f3b31a0f9dde174119f8a6e708d5756e9351c19b0af5aa52ddbd2ee687f1dd4aL2-R2) [[2]](diffhunk://#diff-f3b31a0f9dde174119f8a6e708d5756e9351c19b0af5aa52ddbd2ee687f1dd4aL35-R35)

Dependency removal:

* [`packages/core/package.json`](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L57-R57): Removed the `uuid` dependency as it is no longer used.