### PR TITLE
chore(deps): update `@samchon/openapi` and `typia`

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -47,10 +47,10 @@
   },
   "dependencies": {
     "@agentica/core": "workspace:^",
-    "@samchon/openapi": "^3.2.0",
+    "@samchon/openapi": "^3.2.2",
     "openai": "^4.80.0",
     "tstl": "^3.0.0",
-    "typia": "^8.0.4"
+    "typia": "^8.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -41,14 +41,14 @@
     "@agentica/core": "workspace:^",
     "@mui/icons-material": "^6.4.0",
     "@mui/material": "^6.4.0",
-    "@samchon/openapi": "^3.0.0",
+    "@samchon/openapi": "^3.2.2",
     "html-to-image": "^1.11.13",
     "openai": "^4.80.0",
     "react-markdown": "^9.0.3",
     "rehype-raw": "^7.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-mermaid-plugin": "^1.0.2",
-    "typia": "^8.0.4",
+    "typia": "^8.1.0",
     "uuid": "^11.0.5"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
     "ts-patch": "^3.3.0",
     "type-fest": "^4.37.0",
     "typescript": "~5.8.2",
-    "typia": "^8.0.4",
+    "typia": "^8.1.0",
     "unbuild": "^3.5.0",
     "vitest": "^3.0.9"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,9 +48,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=3.0.0 <4.0.0",
+    "@samchon/openapi": ">=3.2.2 <4.0.0",
     "openai": ">=4.80.0",
-    "typia": ">=8.0.0 <9.0.0"
+    "typia": ">=8.1.0 <9.0.0"
   },
   "dependencies": {
     "@samchon/openapi": "^3.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,8 +53,8 @@
     "typia": ">=8.0.0 <9.0.0"
   },
   "dependencies": {
-    "@samchon/openapi": "^3.2.0",
-    "typia": "^8.0.4",
+    "@samchon/openapi": "^3.2.2",
+    "typia": "^8.1.0",
     "uuid": "^11.0.4"
   },
   "devDependencies": {

--- a/packages/pg-vector-selector/package.json
+++ b/packages/pg-vector-selector/package.json
@@ -53,7 +53,7 @@
     "@agentica/core": "workspace:^",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.1",
-    "@samchon/openapi": "^3",
+    "@samchon/openapi": "^3.2.2",
     "@types/node": "^22.10.5",
     "rimraf": "^6.0.1",
     "rollup": "^4.29.1",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -47,8 +47,8 @@
   },
   "dependencies": {
     "@agentica/core": "workspace:^",
-    "@samchon/openapi": "^3.2.0",
-    "typia": "^8.0.4"
+    "@samchon/openapi": "^3.2.2",
+    "typia": "^8.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@samchon/openapi':
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.2.2
+        version: 3.2.2
       openai:
         specifier: ^4.80.0
         version: 4.89.0(zod@3.24.2)
@@ -48,8 +48,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.0.4
-        version: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+        specifier: ^8.1.0
+        version: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
     devDependencies:
       '@rollup/plugin-terser':
         specifier: ^0.4.4
@@ -88,8 +88,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.8(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@samchon/openapi':
-        specifier: ^3.0.0
-        version: 3.1.0
+        specifier: ^3.2.2
+        version: 3.2.2
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -109,8 +109,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       typia:
-        specifier: ^8.0.4
-        version: 8.0.4(@samchon/openapi@3.1.0)(typescript@5.8.2)
+        specifier: ^8.1.0
+        version: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       uuid:
         specifier: ^11.0.5
         version: 11.1.0
@@ -126,10 +126,10 @@ importers:
         version: 12.1.2(rollup@4.36.0)(tslib@2.8.1)(typescript@5.8.2)
       '@ryoppippi/unplugin-typia':
         specifier: ^2.1.3
-        version: 2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.0.4(@samchon/openapi@3.1.0)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
       '@samchon/shopping-api':
         specifier: ^0.16.0
-        version: 0.16.0(@samchon/openapi@3.1.0)(typescript@5.8.2)
+        version: 0.16.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -211,7 +211,7 @@ importers:
         version: 0.10.0
       '@ryoppippi/unplugin-typia':
         specifier: ^2.1.3
-        version: 2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))
       '@types/node':
         specifier: ^20.14.8
         version: 20.17.25
@@ -246,8 +246,8 @@ importers:
         specifier: ~5.8.2
         version: 5.8.2
       typia:
-        specifier: ^8.0.4
-        version: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+        specifier: ^8.1.0
+        version: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       unbuild:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.8.2)
@@ -262,11 +262,11 @@ importers:
   packages/core:
     dependencies:
       '@samchon/openapi':
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.2.2
+        version: 3.2.2
       typia:
-        specifier: ^8.0.4
-        version: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+        specifier: ^8.1.0
+        version: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       uuid:
         specifier: ^11.0.4
         version: 11.1.0
@@ -318,7 +318,7 @@ importers:
     dependencies:
       '@wrtnlabs/connector-hive-api':
         specifier: ^1.4.1
-        version: 1.4.5(@samchon/openapi@3.1.0)(typescript@5.7.3)
+        version: 1.4.5(@samchon/openapi@3.2.2)(typescript@5.7.3)
     devDependencies:
       '@agentica/core':
         specifier: workspace:^
@@ -330,8 +330,8 @@ importers:
         specifier: ^12.1.1
         version: 12.1.2(rollup@4.36.0)(tslib@2.8.1)(typescript@5.7.3)
       '@samchon/openapi':
-        specifier: ^3
-        version: 3.1.0
+        specifier: ^3.2.2
+        version: 3.2.2
       '@types/node':
         specifier: ^22.10.5
         version: 22.13.9
@@ -351,11 +351,11 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@samchon/openapi':
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.2.2
+        version: 3.2.2
       typia:
-        specifier: ^8.0.4
-        version: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+        specifier: ^8.1.0
+        version: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
     devDependencies:
       '@rollup/plugin-terser':
         specifier: ^0.4.4
@@ -365,7 +365,7 @@ importers:
         version: 12.1.2(rollup@4.36.0)(tslib@2.8.1)(typescript@5.8.2)
       '@samchon/shopping-api':
         specifier: ^0.16.0
-        version: 0.16.0(@samchon/openapi@3.2.0)(typescript@5.8.2)
+        version: 0.16.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.9
@@ -403,11 +403,11 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
       '@samchon/openapi':
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.2.2
+        version: 3.2.2
       '@samchon/shopping-api':
         specifier: ^0.16.0
-        version: 0.16.0(@samchon/openapi@3.2.0)(typescript@5.7.3)
+        version: 0.16.0(@samchon/openapi@3.2.2)(typescript@5.7.3)
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -427,8 +427,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.0.4
-        version: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.7.3)
+        specifier: ^8.1.0
+        version: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.7.3)
     devDependencies:
       ts-node:
         specifier: ^10.9.2
@@ -2376,11 +2376,8 @@ packages:
       vite:
         optional: true
 
-  '@samchon/openapi@3.1.0':
-    resolution: {integrity: sha512-npzlnWTBLpiA6myD6B9WLlQxiEhXVjwLx59CkDGRLPNL5Ok9QYo7wNgP8km1jb9ZwcpdN5j0UW1ukpFIPDGzQw==}
-
-  '@samchon/openapi@3.2.0':
-    resolution: {integrity: sha512-hEpxi53RgDrBGe//M7ThSYuM8ZG3IhwL27MfZ2QK2NnxriWVZPod8RqfyiKmrz6CLRQtyI4mP/Y0Ul7HUdViQQ==}
+  '@samchon/openapi@3.2.2':
+    resolution: {integrity: sha512-ij6qrXDj+uF2Jvz/DPAAQ929QGxAF0dYBL4b+41Y2iogZ8YUR/us9lklFmHYxYKWr450TShWDMCu0jSywUsITQ==}
 
   '@samchon/shopping-api@0.16.0':
     resolution: {integrity: sha512-S51v40tJNW525XSw6h4vxuKWazAFVpMxtm0VoTfb1d6QJu0j44oQ7C8juAKRJ3WtumMmMCAIPWaXSjiO6tfYGg==}
@@ -6936,11 +6933,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@8.0.4:
-    resolution: {integrity: sha512-JPCqinM0PJzQ4DrCqewlQ5YuPAGlAMhEUrMH2iCx67XDRByNxCYgljOau5gWOfkx3ecIi6PfMlmCYPv4RuHRPQ==}
+  typia@8.1.0:
+    resolution: {integrity: sha512-CEP1/vTeU70lEtyoEhJv9NX2pyY+fFZE8Yy0ONDhTS9cREYchZqcpISncjAsuSFH4QH+hu9vkfnOVJTtEMpqLA==}
     hasBin: true
     peerDependencies:
-      '@samchon/openapi': '>=3.0.0 <4.0.0'
+      '@samchon/openapi': '>=3.2.2 <4.0.0'
       typescript: '>=4.8.0 <5.9.0'
 
   uc.micro@2.1.0:
@@ -8520,15 +8517,15 @@ snapshots:
 
   '@nestia/fetcher@5.0.0(typescript@5.7.3)':
     dependencies:
-      '@samchon/openapi': 3.2.0
+      '@samchon/openapi': 3.2.2
       typescript: 5.7.3
-      typia: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.7.3)
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.7.3)
 
   '@nestia/fetcher@5.0.0(typescript@5.8.2)':
     dependencies:
-      '@samchon/openapi': 3.2.0
+      '@samchon/openapi': 3.2.2
       typescript: 5.8.2
-      typia: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
 
   '@next/env@13.5.8': {}
 
@@ -9057,7 +9054,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@ryoppippi/unplugin-typia@2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.0.4(@samchon/openapi@3.1.0)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
+  '@ryoppippi/unplugin-typia@2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
       consola: 3.4.2
@@ -9069,58 +9066,47 @@ snapshots:
       pkg-types: 2.1.0
       type-fest: 4.37.0
       typescript: 5.8.2
-      typia: 8.0.4(@samchon/openapi@3.1.0)(typescript@5.8.2)
-      unplugin: 2.2.2
-    optionalDependencies:
-      vite: 5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0)
-    transitivePeerDependencies:
-      - rollup
-
-  '@ryoppippi/unplugin-typia@2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))':
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
-      consola: 3.4.2
-      defu: 6.1.4
-      diff-match-patch-es: 1.0.1
-      find-cache-dir: 5.0.0
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      pkg-types: 2.1.0
-      type-fest: 4.37.0
-      typescript: 5.8.2
-      typia: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       unplugin: 2.2.2
     optionalDependencies:
       vite: 5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0)
     transitivePeerDependencies:
       - rollup
 
-  '@samchon/openapi@3.1.0': {}
-
-  '@samchon/openapi@3.2.0': {}
-
-  '@samchon/shopping-api@0.16.0(@samchon/openapi@3.1.0)(typescript@5.8.2)':
+  '@ryoppippi/unplugin-typia@2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
-      '@nestia/fetcher': 5.0.0(typescript@5.8.2)
-      typia: 8.0.4(@samchon/openapi@3.1.0)(typescript@5.8.2)
-      uuid: 11.1.0
+      '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
+      consola: 3.4.2
+      defu: 6.1.4
+      diff-match-patch-es: 1.0.1
+      find-cache-dir: 5.0.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      pkg-types: 2.1.0
+      type-fest: 4.37.0
+      typescript: 5.8.2
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
+      unplugin: 2.2.2
+    optionalDependencies:
+      vite: 5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0)
     transitivePeerDependencies:
-      - '@samchon/openapi'
-      - typescript
+      - rollup
 
-  '@samchon/shopping-api@0.16.0(@samchon/openapi@3.2.0)(typescript@5.7.3)':
+  '@samchon/openapi@3.2.2': {}
+
+  '@samchon/shopping-api@0.16.0(@samchon/openapi@3.2.2)(typescript@5.7.3)':
     dependencies:
       '@nestia/fetcher': 5.0.0(typescript@5.7.3)
-      typia: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.7.3)
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.7.3)
       uuid: 11.1.0
     transitivePeerDependencies:
       - '@samchon/openapi'
       - typescript
 
-  '@samchon/shopping-api@0.16.0(@samchon/openapi@3.2.0)(typescript@5.8.2)':
+  '@samchon/shopping-api@0.16.0(@samchon/openapi@3.2.2)(typescript@5.8.2)':
     dependencies:
       '@nestia/fetcher': 5.0.0(typescript@5.8.2)
-      typia: 8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2)
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2)
       uuid: 11.1.0
     transitivePeerDependencies:
       - '@samchon/openapi'
@@ -9832,11 +9818,11 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
-  '@wrtnlabs/connector-hive-api@1.4.5(@samchon/openapi@3.1.0)(typescript@5.7.3)':
+  '@wrtnlabs/connector-hive-api@1.4.5(@samchon/openapi@3.2.2)(typescript@5.7.3)':
     dependencies:
       '@nestia/fetcher': 5.0.0(typescript@5.7.3)
       tgrid: 1.1.0
-      typia: 8.0.4(@samchon/openapi@3.1.0)(typescript@5.7.3)
+      typia: 8.1.0(@samchon/openapi@3.2.2)(typescript@5.7.3)
     transitivePeerDependencies:
       - '@samchon/openapi'
       - bufferutil
@@ -11051,8 +11037,8 @@ snapshots:
       '@typescript-eslint/parser': 8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.22.0(jiti@2.4.2))
@@ -11087,7 +11073,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -11098,7 +11084,7 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-import-x: 4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
@@ -11123,14 +11109,14 @@ snapshots:
     dependencies:
       eslint: 9.23.0(jiti@2.4.2)
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -11231,7 +11217,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -11242,7 +11228,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.9.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15224,9 +15210,9 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typia@8.0.4(@samchon/openapi@3.1.0)(typescript@5.7.3):
+  typia@8.1.0(@samchon/openapi@3.2.2)(typescript@5.7.3):
     dependencies:
-      '@samchon/openapi': 3.1.0
+      '@samchon/openapi': 3.2.2
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6
@@ -15234,29 +15220,9 @@ snapshots:
       randexp: 0.5.3
       typescript: 5.7.3
 
-  typia@8.0.4(@samchon/openapi@3.1.0)(typescript@5.8.2):
+  typia@8.1.0(@samchon/openapi@3.2.2)(typescript@5.8.2):
     dependencies:
-      '@samchon/openapi': 3.1.0
-      commander: 10.0.1
-      comment-json: 4.2.5
-      inquirer: 8.2.6
-      package-manager-detector: 0.2.11
-      randexp: 0.5.3
-      typescript: 5.8.2
-
-  typia@8.0.4(@samchon/openapi@3.2.0)(typescript@5.7.3):
-    dependencies:
-      '@samchon/openapi': 3.2.0
-      commander: 10.0.1
-      comment-json: 4.2.5
-      inquirer: 8.2.6
-      package-manager-detector: 0.2.11
-      randexp: 0.5.3
-      typescript: 5.7.3
-
-  typia@8.0.4(@samchon/openapi@3.2.0)(typescript@5.8.2):
-    dependencies:
-      '@samchon/openapi': 3.2.0
+      '@samchon/openapi': 3.2.2
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "@agentica/pg-vector-selector": "workspace:^",
     "@agentica/rpc": "workspace:^",
     "@nestia/e2e": "^0.8.2",
-    "@samchon/openapi": "^3.2.0",
+    "@samchon/openapi": "^3.2.2",
     "@samchon/shopping-api": "^0.16.0",
     "chalk": "4.1.2",
     "dotenv": "^16.4.7",
@@ -27,7 +27,7 @@
     "openai": "^4.80.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^8.0.4"
+    "typia": "^8.1.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",


### PR DESCRIPTION
Updated with:
```sh
pnpx taze -wr --include typia,@samchon/openapi
pnpm install
```

This pull request includes various updates to package dependencies across multiple files, primarily upgrading the versions of `@samchon/openapi` and `typia` packages.

Dependency Updates:

* Updated `@samchon/openapi` from `^3.2.0` or `^3.0.0` to `^3.2.2` in `package.json` files for `benchmark`, `chat`, `core`, `pg-vector-selector`, and `rpc` packages. [[1]](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1L50-R53) [[2]](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL44-R51) [[3]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L56-R57) [[4]](diffhunk://#diff-17c97c54e8f9e9e170b125f77d0288d568fcbc648384108b88347b62b6f5e09fL56-R56) [[5]](diffhunk://#diff-68aaf91f74a0ea0d392cd7e8a0bd6de0a8cff7abdd251b6b9875111556003650L50-R51)
* Updated `typia` from `^8.0.4` to `^8.1.0` in `package.json` files for `benchmark`, `chat`, `cli`, `core`, and `rpc` packages. [[1]](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1L50-R53) [[2]](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL44-R51) [[3]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L71-R71) [[4]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L56-R57) [[5]](diffhunk://#diff-68aaf91f74a0ea0d392cd7e8a0bd6de0a8cff7abdd251b6b9875111556003650L50-R51)

`pnpm-lock.yaml` Synchronization:

* Updated `@samchon/openapi` to `3.2.2` and `typia` to `8.1.0` in the `pnpm-lock.yaml` file to reflect the changes in the package dependencies. This includes multiple updates in various sections of the file to ensure consistency with the new versions. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL42-R52) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL91-R92) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL112-R113) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL129-R132) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL214-R214) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL249-R250) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL265-R269) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL321-R321) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL333-R334) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL354-R358) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL368-R368) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL406-R410) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL430-R431) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2379-R2380) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6939-R6940) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8523-R8528) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9060-R9057) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9072-R9076) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9091-R9109) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9835-R9825) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11054-R11041) [[22]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11090-R11076)