### PR TITLE
fix(cli): process.exit instead of start

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ program
       p.log.error(
         `\n❌ The value of ${picocolors.redBright("--project")} is required`,
       );
-      return;
+      process.exit(1);
     }
 
     /** check valid project type */
@@ -43,7 +43,7 @@ program
       p.log.error(
         `\n❌ The value of ${picocolors.redBright("--project")} is invalid`,
       );
-      return;
+      process.exit(1);
     }
 
     p.intro(`🚀 ${picocolors.blueBright("Agentica")} Setup Wizard`);


### PR DESCRIPTION
This pull request includes a change to the `packages/cli/src/index.ts` file to improve error handling in the program. The most important change involves replacing the `return` statements with `process.exit(1)` to ensure the program exits with a non-zero status code when an error occurs.

Error handling improvement:

* [`packages/cli/src/index.ts`](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL38-R46): Replaced `return` statements with `process.exit(1)` to ensure the program exits with a non-zero status code when an error occurs.