### PR TITLE
fix(cli): publishing config

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "LICENSE",
     "README.md",
     "bin",
+    "dist",
     "package.json"
   ],
   "engines": {


### PR DESCRIPTION
This pull request includes a small change to the `packages/cli/package.json` file. The change adds the `dist` directory to the list of files included in the package.