### PR TITLE
feat(cli): add map file for trace error

### DIFF
--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -22,4 +22,5 @@ export default defineBuildConfig({
       minify: true,
     },
   },
+  sourcemap: true,
 });


### PR DESCRIPTION
This pull request includes a small change to the `packages/cli/build.config.ts` file. The change enables the generation of source maps in the build configuration.

* [`packages/cli/build.config.ts`](diffhunk://#diff-9a7382d3037f737c8c0654204114d28ce916c4944d7dd8608f19cf27f63b73e0R25): Added the `sourcemap` option to the build configuration to generate source maps.