### PR TITLE
fix: fix the order of packagemanger install

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -67,11 +67,11 @@ async function installServicesAsDependencies({ packageManager, projectAbsolutePa
 
   s.start("📦 Package installation in progress...");
 
-  await execAsync(prepareCommand, {
+  await execAsync(command, {
     cwd: projectAbsolutePath,
   });
 
-  await execAsync(command, {
+  await execAsync(prepareCommand, {
     cwd: projectAbsolutePath,
   });
 


### PR DESCRIPTION
## Description
- fix the order of packageMangaer install command in `installServicesAsDependencies`