### PR TITLE
test(cli): stop mocking for start command and test with all package managers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,15 @@ on:
 jobs:
   packages-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, '22.x']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: ${{ matrix.node-version }}
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,2 @@
-.tmp/
 !bin
 dist

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -1,11 +1,11 @@
 /** it is hard to mock fs because we have gigetDownload here, so we use tmp directory */
 
-import type { exec } from "node:child_process";
 import type { PackageJson } from "type-fest";
 import type { Service } from "../connectors";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { resolve } from "node:path";
+import { PACKAGE_MANAGERS } from "../packages";
 import {
   setupNestJSProject,
   setupNodeJSProject,
@@ -13,235 +13,218 @@ import {
   setupStandAloneProject,
 } from "./start";
 
-/**
- * mock execAsync to avoid installing packages
- * because it causes timeout when running on CI
- */
-vi.mock("../utils", async () => ({
-  /** import actual utils module */
-  ...(await vi.importActual("../utils")),
-  /** mock execAsync */
-  execAsync(...args: Parameters<typeof exec>) {
-    const [command, options] = args;
-    const directory = (options?.cwd ?? import.meta.dirname) as string;
-    const [, ...packages] = command.split(" ");
-    const packageJson = JSON.parse(readFileSync(resolve(directory, "package.json"), "utf-8")) as PackageJson;
-    packageJson.dependencies ??= {};
-    for (const pkg of packages) {
-      packageJson.dependencies[pkg] = "latest";
-    }
-    writeFileSync(resolve(directory, "package.json"), JSON.stringify(packageJson, null, 2));
-  },
-}));
-
 beforeAll(async () => {
   await rm(resolve(import.meta.dirname, ".tmp"), { recursive: true, force: true });
 });
 
-describe("setupStandAloneProject", () => {
-  it("should create a new directory and set project .env file", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/standalone");
+describe("start command integration test", { timeout: 60_000 }, () => {
+  describe.each(PACKAGE_MANAGERS)("packageManager: %s", (packageManager) => {
+    describe("setupStandAloneProject", () => {
+      it("should create a new directory and set project .env file", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/standalone");
 
-    await setupStandAloneProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        openAIKey: "sk-foo",
-        services: [],
-      },
+        await setupStandAloneProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            openAIKey: "sk-foo",
+            services: [],
+          },
+        });
+
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+
+        // check template is standalone project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-standalone");
+
+        // check if the .env file exists
+        expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
+        // check if the .env file contains OPENAI_API_KEY
+        expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo");
+      });
+
+      it("should create a new directory and set project with services", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/standalone-with-google-map");
+
+        await setupStandAloneProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            openAIKey: "",
+            services: ["google-map" as Service],
+          },
+        });
+
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+
+        // check template is standalone project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-standalone");
+
+        // check if `@wrtnlabs/connector-google-map` is installed
+        expect(packageJson.dependencies).toHaveProperty("@wrtnlabs/connector-google-map");
+
+        // index.ts includes google-map connector
+        const indexTs = await readFile(resolve(destinationDirectory, "src/index.ts"), "utf-8");
+        expect(indexTs).toContain(`import { GoogleMapService } from "@wrtnlabs/connector-google-map";`);
+        expect(indexTs).toContain(`name: "GoogleMap Connector",`);
+        expect(indexTs).toContain(`application: typia.llm.application<GoogleMapService, "chatgpt">(),`);
+        expect(indexTs).toContain(`execute: new GoogleMapService(),`);
+      });
     });
 
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+    describe("setupNodeJSProject", () => {
+      it("should create a new directory and set project .env file", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nodejs");
 
-    // check template is standalone project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-standalone");
+        await setupNodeJSProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            openAIKey: "sk-foo",
+            port: 3000,
+            services: [],
+          },
+        });
 
-    // check if the .env file exists
-    expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
-    // check if the .env file contains OPENAI_API_KEY
-    expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo");
-  });
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
 
-  it("should create a new directory and set project with services", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/standalone-with-google-map");
+        // check template is nodejs project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-nodejs");
 
-    await setupStandAloneProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        openAIKey: "",
-        services: ["google-map" as Service],
-      },
+        // check if the .env file exists
+        expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
+        // check if the .env file contains OPENAI_API_KEY and PORT
+        expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo\nPORT=3000");
+      });
+
+      it("should create a new directory and set project with services", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nodejs-with-google-map");
+
+        await setupNodeJSProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            openAIKey: "",
+            services: ["google-map" as Service],
+          },
+        });
+
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+
+        // check template is nodejs project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-nodejs");
+
+        // check if `@wrtnlabs/connector-google-map` is installed
+        expect(packageJson.dependencies).toHaveProperty("@wrtnlabs/connector-google-map");
+
+        // index.ts includes google-map connector
+        const indexTs = await readFile(resolve(destinationDirectory, "src/index.ts"), "utf-8");
+        expect(indexTs).toContain(`import { GoogleMapService } from "@wrtnlabs/connector-google-map";`);
+        expect(indexTs).toContain(`name: "GoogleMap Connector",`);
+        expect(indexTs).toContain(`application: typia.llm.application<GoogleMapService, "chatgpt">(),`);
+        expect(indexTs).toContain(`execute: new GoogleMapService(),`);
+      });
     });
 
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+    describe("setupNestJSProject", () => {
+      it("should create a new directory and set project .env file", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nestjs");
 
-    // check template is standalone project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-standalone");
+        await setupNestJSProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            openAIKey: "sk-foo",
+            port: 3000,
+            services: [],
+          },
+        });
 
-    // check if `@wrtnlabs/connector-google-map` is installed
-    expect(packageJson.dependencies).toHaveProperty("@wrtnlabs/connector-google-map");
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
 
-    // index.ts includes google-map connector
-    const indexTs = await readFile(resolve(destinationDirectory, "src/index.ts"), "utf-8");
-    expect(indexTs).toContain(`import { GoogleMapService } from "@wrtnlabs/connector-google-map";`);
-    expect(indexTs).toContain(`name: "GoogleMap Connector",`);
-    expect(indexTs).toContain(`application: typia.llm.application<GoogleMapService, "chatgpt">(),`);
-    expect(indexTs).toContain(`execute: new GoogleMapService(),`);
-  });
-});
+        // check template is nestjs project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-nestjs");
 
-describe("setupNodeJSProject", () => {
-  it("should create a new directory and set project .env file", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/nodejs");
+        // check if the .env file exists
+        expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
+        // check if the .env file contains OPENAI_API_KEY and PORT
+        expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo\nAPI_PORT=3000");
+      });
 
-    await setupNodeJSProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        openAIKey: "sk-foo",
-        port: 3000,
-        services: [],
-      },
+      it("should create a new directory and set project with services", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nestjs-with-google-map");
+
+        await setupNestJSProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            openAIKey: "",
+            services: ["google-map" as Service],
+          },
+        });
+
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+
+        // check template is nestjs project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-nestjs");
+
+        // check if `@wrtnlabs/connector-google-map` is installed
+        expect(packageJson.dependencies).toHaveProperty("@wrtnlabs/connector-google-map");
+
+        // index.ts includes google-map connector
+        const indexTs = await readFile(resolve(destinationDirectory, "src/controllers/chat/ChatController.ts"), "utf-8");
+        expect(indexTs).toContain(`import { GoogleMapService } from "@wrtnlabs/connector-google-map";`);
+        expect(indexTs).toContain(`name: "GoogleMap Connector",`);
+        expect(indexTs).toContain(`application: typia.llm.application<GoogleMapService, "chatgpt">(),`);
+        expect(indexTs).toContain(`execute: new GoogleMapService(),`);
+      });
     });
 
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
+    describe("setupReactProject", () => {
+      it("should create a new directory and set project .env file", async () => {
+        const destinationDirectory = resolve(import.meta.dirname, ".tmp/react");
 
-    // check template is nodejs project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-nodejs");
+        await setupReactProject({
+          projectAbsolutePath: destinationDirectory,
+          context: {
+            packageManager,
+            port: 3000,
+            openAIKey: "sk-foo",
+            services: [],
+          },
+        });
 
-    // check if the .env file exists
-    expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
-    // check if the .env file contains OPENAI_API_KEY and PORT
-    expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo\nPORT=3000");
-  });
+        // check if the directory exists
+        expect(existsSync(destinationDirectory)).toBe(true);
+        expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
 
-  it("should create a new directory and set project with services", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/nodejs-with-google-map");
+        // check template is react project
+        const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
+        expect(packageJson.name).toBe("agentica-template-react");
 
-    await setupNodeJSProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        openAIKey: "",
-        services: ["google-map" as Service],
-      },
+        // check if the .env file exists
+        expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
+        // check if the .env file contains OPENAI_API_KEY
+        expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo\nVITE_AGENTICA_WS_URL=ws://localhost:3000/chat");
+      });
     });
-
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
-
-    // check template is nodejs project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-nodejs");
-
-    // check if `@wrtnlabs/connector-google-map` is installed
-    expect(packageJson.dependencies).toHaveProperty("@wrtnlabs/connector-google-map");
-
-    // index.ts includes google-map connector
-    const indexTs = await readFile(resolve(destinationDirectory, "src/index.ts"), "utf-8");
-    expect(indexTs).toContain(`import { GoogleMapService } from "@wrtnlabs/connector-google-map";`);
-    expect(indexTs).toContain(`name: "GoogleMap Connector",`);
-    expect(indexTs).toContain(`application: typia.llm.application<GoogleMapService, "chatgpt">(),`);
-    expect(indexTs).toContain(`execute: new GoogleMapService(),`);
-  });
-});
-
-describe("setupNestJSProject", () => {
-  it("should create a new directory and set project .env file", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/nestjs");
-
-    await setupNestJSProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        openAIKey: "sk-foo",
-        port: 3000,
-        services: [],
-      },
-    });
-
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
-
-    // check template is nestjs project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-nestjs");
-
-    // check if the .env file exists
-    expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
-    // check if the .env file contains OPENAI_API_KEY and PORT
-    expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo\nAPI_PORT=3000");
-  });
-
-  it("should create a new directory and set project with services", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/nestjs-with-google-map");
-
-    await setupNestJSProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        openAIKey: "",
-        services: ["google-map" as Service],
-      },
-    });
-
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
-
-    // check template is nestjs project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-nestjs");
-
-    // check if `@wrtnlabs/connector-google-map` is installed
-    expect(packageJson.dependencies).toHaveProperty("@wrtnlabs/connector-google-map");
-
-    // index.ts includes google-map connector
-    const indexTs = await readFile(resolve(destinationDirectory, "src/controllers/chat/ChatController.ts"), "utf-8");
-    expect(indexTs).toContain(`import { GoogleMapService } from "@wrtnlabs/connector-google-map";`);
-    expect(indexTs).toContain(`name: "GoogleMap Connector",`);
-    expect(indexTs).toContain(`application: typia.llm.application<GoogleMapService, "chatgpt">(),`);
-    expect(indexTs).toContain(`execute: new GoogleMapService(),`);
-  });
-});
-
-describe("setupReactProject", () => {
-  it("should create a new directory and set project .env file", async () => {
-    const destinationDirectory = resolve(import.meta.dirname, ".tmp/react");
-
-    await setupReactProject({
-      projectAbsolutePath: destinationDirectory,
-      context: {
-        packageManager: "pnpm",
-        port: 3000,
-        openAIKey: "sk-foo",
-        services: [],
-      },
-    });
-
-    // check if the directory exists
-    expect(existsSync(destinationDirectory)).toBe(true);
-    expect(existsSync(resolve(destinationDirectory, "package.json"))).toBe(true);
-
-    // check template is react project
-    const packageJson = JSON.parse(await readFile(resolve(destinationDirectory, "package.json"), "utf-8")) as PackageJson;
-    expect(packageJson.name).toBe("agentica-template-react");
-
-    // check if the .env file exists
-    expect(existsSync(resolve(destinationDirectory, ".env"))).toBe(true);
-    // check if the .env file contains OPENAI_API_KEY
-    expect(await readFile(resolve(destinationDirectory, ".env"), "utf-8")).toBe("OPENAI_API_KEY=sk-foo\nVITE_AGENTICA_WS_URL=ws://localhost:3000/chat");
   });
 });

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -27,8 +27,10 @@ function generateRandomAlphanumericString(length: number): string {
   return result;
 }
 
+const PACKAGE_MANAGERS_WITHOUT_YARN = PACKAGE_MANAGERS.filter(packageManager => packageManager !== "yarn");
 describe("start command integration test", () => {
-  describe.each(PACKAGE_MANAGERS)("packageManager: %s", { timeout: 1_000_000, concurrent: true }, (packageManager) => {
+  it.todo("we support yarn but it doesn't work on CI, so we need to fix it");
+  describe.each(PACKAGE_MANAGERS_WITHOUT_YARN)("packageManager: %s", { timeout: 1_000_000, concurrent: true }, (packageManager) => {
     const tmpParentDirectory = resolve(tmpdir(), generateRandomAlphanumericString(8));
     afterAll(async () => {
       await rm(tmpParentDirectory, { recursive: true, force: true });

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -4,6 +4,7 @@ import type { PackageJson } from "type-fest";
 import type { Service } from "../connectors";
 import { existsSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { PACKAGE_MANAGERS } from "../packages";
 import {
@@ -13,15 +14,29 @@ import {
   setupStandAloneProject,
 } from "./start";
 
-beforeAll(async () => {
-  await rm(resolve(import.meta.dirname, ".tmp"), { recursive: true, force: true });
-});
+function generateRandomAlphanumericString(length: number): string {
+  const alphabet
+    = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let result = "";
 
-describe("start command integration test", { timeout: 60_000 }, () => {
-  describe.each(PACKAGE_MANAGERS)("packageManager: %s", (packageManager) => {
+  for (let i = 0; i < length; i++) {
+    const randomIndex = Math.floor(Math.random() * alphabet.length);
+    result += alphabet[randomIndex];
+  }
+
+  return result;
+}
+
+describe("start command integration test", () => {
+  describe.each(PACKAGE_MANAGERS)("packageManager: %s", { timeout: 1_000_000, concurrent: true }, (packageManager) => {
+    const tmpParentDirectory = resolve(tmpdir(), generateRandomAlphanumericString(8));
+    afterAll(async () => {
+      await rm(tmpParentDirectory, { recursive: true, force: true });
+    }, 60_000);
+
     describe("setupStandAloneProject", () => {
       it("should create a new directory and set project .env file", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/standalone");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/standalone");
 
         await setupStandAloneProject({
           projectAbsolutePath: destinationDirectory,
@@ -47,7 +62,7 @@ describe("start command integration test", { timeout: 60_000 }, () => {
       });
 
       it("should create a new directory and set project with services", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/standalone-with-google-map");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/standalone-with-google-map");
 
         await setupStandAloneProject({
           projectAbsolutePath: destinationDirectory,
@@ -80,7 +95,7 @@ describe("start command integration test", { timeout: 60_000 }, () => {
 
     describe("setupNodeJSProject", () => {
       it("should create a new directory and set project .env file", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nodejs");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/nodejs");
 
         await setupNodeJSProject({
           projectAbsolutePath: destinationDirectory,
@@ -107,7 +122,7 @@ describe("start command integration test", { timeout: 60_000 }, () => {
       });
 
       it("should create a new directory and set project with services", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nodejs-with-google-map");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/nodejs-with-google-map");
 
         await setupNodeJSProject({
           projectAbsolutePath: destinationDirectory,
@@ -140,7 +155,7 @@ describe("start command integration test", { timeout: 60_000 }, () => {
 
     describe("setupNestJSProject", () => {
       it("should create a new directory and set project .env file", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nestjs");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/nestjs");
 
         await setupNestJSProject({
           projectAbsolutePath: destinationDirectory,
@@ -167,7 +182,7 @@ describe("start command integration test", { timeout: 60_000 }, () => {
       });
 
       it("should create a new directory and set project with services", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/nestjs-with-google-map");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/nestjs-with-google-map");
 
         await setupNestJSProject({
           projectAbsolutePath: destinationDirectory,
@@ -200,7 +215,7 @@ describe("start command integration test", { timeout: 60_000 }, () => {
 
     describe("setupReactProject", () => {
       it("should create a new directory and set project .env file", async () => {
-        const destinationDirectory = resolve(import.meta.dirname, ".tmp/react");
+        const destinationDirectory = resolve(tmpParentDirectory, ".tmp/react");
 
         await setupReactProject({
           projectAbsolutePath: destinationDirectory,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -60,8 +60,8 @@ interface InstallDependenciesOptions {
 
 /** dependencies for the project */
 async function installServicesAsDependencies({ packageManager, projectAbsolutePath, services }: InstallDependenciesOptions): Promise<void> {
-  // in case service is empty we add dummy package. we use typescript for sure, so we use it.
-  const pkg = ([...services.map(service => serviceToConnector(service)), "typescript"]).join(" ");
+  /* if no services are selected, undefined is passed to the package manager */
+  const pkg = services.length > 0 ? ([...services.map(service => serviceToConnector(service))]).join(" ") : undefined;
   const command = installCommand({ packageManager, pkg });
 
   const s = p.spinner();

--- a/packages/cli/src/packages.test.ts
+++ b/packages/cli/src/packages.test.ts
@@ -13,16 +13,22 @@ describe("installCommand", () => {
     expect(result).toBe("yarn add openai");
   });
 
+  it("yarn without package", () => {
+    const packageManager = "yarn";
+    const result = installCommand({ packageManager });
+    expect(result).toBe("yarn");
+  });
+
   it("pnpm", () => {
     const packageManager = "pnpm";
     const result = installCommand({ packageManager, pkg: "openai" });
-    expect(result).toBe("pnpm add openai");
+    expect(result).toBe("pnpm install openai");
   });
 
   it("bun", () => {
     const packageManager = "bun";
     const result = installCommand({ packageManager, pkg: "openai" });
-    expect(result).toBe("bun add openai");
+    expect(result).toBe("bun install openai");
   });
 
   it("unsupported", () => {

--- a/packages/cli/src/packages.ts
+++ b/packages/cli/src/packages.ts
@@ -6,12 +6,15 @@
 import type { PackageJson } from "type-fest";
 import process from "node:process";
 
+export const PACKAGE_MANAGERS = [
+  "npm",
+  "yarn",
+  "pnpm",
+  "bun",
+] as const;
+
 /** supported package managers */
-export type PackageManager =
-  | "npm"
-  | "yarn"
-  | "pnpm"
-  | "bun";
+export type PackageManager = typeof PACKAGE_MANAGERS[number];
 
 export const basePackageJson = {
   version: "0.0.1",

--- a/packages/cli/src/packages.ts
+++ b/packages/cli/src/packages.ts
@@ -29,7 +29,7 @@ export const basePackageJson = {
 
 interface InstallProps {
   packageManager: PackageManager;
-  pkg: string;
+  pkg?: string;
 }
 
 /**
@@ -40,11 +40,11 @@ export function installCommand({ packageManager, pkg }: InstallProps) {
     case "npm":
       return `npm install ${pkg}`;
     case "yarn":
-      return `yarn add ${pkg}`;
+      return pkg != null ? `yarn add ${pkg}` : "yarn";
     case "pnpm":
-      return `pnpm add ${pkg}`;
+      return `pnpm install ${pkg}`;
     case "bun":
-      return `bun add ${pkg}`;
+      return `bun install ${pkg}`;
     default:
       /** exhaustive check */
       packageManager satisfies never;


### PR DESCRIPTION
This pull request includes several changes to the testing setup, package management, and codebase simplification. The most important changes include adding support for multiple Node.js versions in the CI workflow, refactoring the test setup to use temporary directories, and updating package manager commands.

### CI Workflow Improvements:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R11-R20): Added a strategy matrix to test against multiple Node.js versions (18.x, 20.x, 22.x) and configured the setup to use the appropriate Node.js version for each job.

### Test Setup Refactoring:
* [`packages/cli/src/commands/start.test.ts`](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL3-R46): Refactored the test setup to use temporary directories generated at runtime instead of a fixed `.tmp` directory. This change ensures that tests run in isolated environments and reduces the risk of conflicts. [[1]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL3-R46) [[2]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL69-R72) [[3]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL102-R105) [[4]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL129-R132) [[5]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL162-R165) [[6]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL189-R192) [[7]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbL222-R225) [[8]](diffhunk://#diff-cad17d10af917b03d1bcd2cbe447e2e6caed5226042bde8c47133f2017c9cbcbR246-R247)

### Package Management Updates:
* [`packages/cli/src/packages.ts`](diffhunk://#diff-a3146aabcd66971041f2d4863d0be556320ab4cfcab4d272c6c18d8c6e0fed5fR9-R17): Introduced a constant array `PACKAGE_MANAGERS` for supported package managers and updated the `installCommand` function to handle cases where no packages are specified. This change ensures that the correct commands are used for each package manager. [[1]](diffhunk://#diff-a3146aabcd66971041f2d4863d0be556320ab4cfcab4d272c6c18d8c6e0fed5fR9-R17) [[2]](diffhunk://#diff-a3146aabcd66971041f2d4863d0be556320ab4cfcab4d272c6c18d8c6e0fed5fL29-R32) [[3]](diffhunk://#diff-a3146aabcd66971041f2d4863d0be556320ab4cfcab4d272c6c18d8c6e0fed5fL40-R47)
* [`packages/cli/src/commands/start.ts`](diffhunk://#diff-6858dc88bcb8c8d88063b185a5bddbe2709171731c56c401cbf793bf7ff5baa1L63-R64): Modified the `installServicesAsDependencies` function to handle cases where no services are selected, passing `undefined` to the package manager if the services list is empty.

### Test Enhancements:
* [`packages/cli/src/packages.test.ts`](diffhunk://#diff-e74006a01b81073bc741d331f5e0b74dbf46f591d6319a75c5e674898f5436c7R16-R31): Added a test case to verify the behavior of the `installCommand` function when no package is specified for the `yarn` package manager.

### .gitignore Update:
* [`packages/cli/.gitignore`](diffhunk://#diff-9fe1c9b20a6f95851566baf974a3e3b9f81b7df7e26b5c8a80d16eb48a66e2b9L1): Removed the `.tmp/` entry to ensure temporary files are not ignored during testing.