### PR TITLE
fix(core): prepare command error

### DIFF
--- a/packages/core/build/prompt.js
+++ b/packages/core/build/prompt.js
@@ -21,7 +21,7 @@ async function main() {
       .trim();
   }
   await fs.promises.writeFile(
-    path.join(__dirname, "../src/internal/AgenticaSystemPrompt.ts"),
+    path.join(__dirname, "../src/constants/AgenticaSystemPrompt.ts"),
     [
       `/* eslint-disable no-template-curly-in-string */`,
       `export const AgenticaSystemPrompt = {`,


### PR DESCRIPTION
This pull request includes a small change to the `async function main()` in the `packages/core/build/prompt.js` file. The change updates the file path for writing the `AgenticaSystemPrompt.ts` file.

* [`packages/core/build/prompt.js`](diffhunk://#diff-977c3a67c50403a73980530b0478352c2698fa59682eee22bd20f86c8a35a4e6L24-R24): Updated the file path from `../src/internal/AgenticaSystemPrompt.ts` to `../src/constants/AgenticaSystemPrompt.ts` in the `fs.promises.writeFile` call.