### PR TITLE
fix(cli): handle undefined package in install commands

### DIFF
--- a/packages/cli/src/packages.test.ts
+++ b/packages/cli/src/packages.test.ts
@@ -7,6 +7,12 @@ describe("installCommand", () => {
     expect(result).toBe("npm install openai");
   });
 
+  it("npm without package", () => {
+    const packageManager = "npm";
+    const result = installCommand({ packageManager });
+    expect(result).toBe("npm install ");
+  });
+
   it("yarn", () => {
     const packageManager = "yarn";
     const result = installCommand({ packageManager, pkg: "openai" });
@@ -25,10 +31,22 @@ describe("installCommand", () => {
     expect(result).toBe("pnpm install openai");
   });
 
+  it("pnpm without package", () => {
+    const packageManager = "pnpm";
+    const result = installCommand({ packageManager });
+    expect(result).toBe("pnpm install ");
+  });
+
   it("bun", () => {
     const packageManager = "bun";
     const result = installCommand({ packageManager, pkg: "openai" });
     expect(result).toBe("bun install openai");
+  });
+
+  it("bun without package", () => {
+    const packageManager = "bun";
+    const result = installCommand({ packageManager });
+    expect(result).toBe("bun install ");
   });
 
   it("unsupported", () => {

--- a/packages/cli/src/packages.ts
+++ b/packages/cli/src/packages.ts
@@ -38,13 +38,13 @@ interface InstallProps {
 export function installCommand({ packageManager, pkg }: InstallProps) {
   switch (packageManager) {
     case "npm":
-      return `npm install ${pkg}`;
+      return `npm install ${pkg ?? ""}`;
     case "yarn":
       return pkg != null ? `yarn add ${pkg}` : "yarn";
     case "pnpm":
-      return `pnpm install ${pkg}`;
+      return `pnpm install ${pkg ?? ""}`;
     case "bun":
-      return `bun install ${pkg}`;
+      return `bun install ${pkg ?? ""}`;
     default:
       /** exhaustive check */
       packageManager satisfies never;


### PR DESCRIPTION
Added null coalescence to handle undefined package parameter in npm, pnpm, and bun install commands, ensuring they still generate valid commands even when no package is specified. Added tests to verify this behavior.