### PR TITLE
fix(cli): lower Node.js version requirement to 18.18.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "package.json"
   ],
   "engines": {
-    "node": ">=20.12.0"
+    "node": ">=18.18.0"
   },
   "scripts": {
     "prepare": "ts-patch install",


### PR DESCRIPTION
we test our cli with node.js 18 and it works!
So we modify `engine` field