### PR TITLE
fix(ci): breaked lint-check on CI

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -17,4 +17,5 @@ jobs:
 
       - name: Lint
         # `pnpm lint` is not emit error exit code, so we need to check the output
-        run: pnpm lint | tee >(tail -n1 | grep -q 'Failed') && exit 1 || exit 0
+        # run: pnpm lint | tee >(tail -n1 | grep -q 'Failed') && exit 1 || exit 0
+        run: pnpm dlx npm-run-all2 -p lint:* --aggregate-output

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -16,6 +16,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        # `pnpm lint` is not emit error exit code, so we need to check the output
-        # run: pnpm lint | tee >(tail -n1 | grep -q 'Failed') && exit 1 || exit 0
         run: pnpm dlx npm-run-all2 -p lint:* --aggregate-output


### PR DESCRIPTION
This pull request includes a change to the linting job in the GitHub Actions workflow file `.github/workflows/lint-check.yml`. The change updates the command used for linting to simplify the process and ensure proper error handling.

Changes to linting job:

* [`.github/workflows/lint-check.yml`](diffhunk://#diff-dda267615bb53af994fa659ec8de11a5c4855ee18b1922370924f65759d8cae1L19-R19): Updated the linting command to use `pnpm dlx npm-run-all2 -p lint:* --aggregate-output` instead of the previous command which manually checked the output for errors.