### PR TITLE
feat(pg-vector-selector): add unit test

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
     "std-env": "^3.8.1",
     "ts-node": "^10.9.2",
     "ts-patch": "catalog:typia",
-    "type-fest": "^4.37.0",
+    "type-fest": "catalog:libs",
     "typescript": "catalog:libs",
     "typia": "catalog:typia",
     "unbuild": "^3.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,6 @@
     "typescript": "catalog:libs",
     "typia": "catalog:typia",
     "unbuild": "^3.5.0",
-    "vitest": "^3.0.9"
+    "vitest": "catalog:vite"
   }
 }

--- a/packages/pg-vector-selector/eslint.config.mts
+++ b/packages/pg-vector-selector/eslint.config.mts
@@ -1,5 +1,5 @@
 import { wrtnlabs } from "@wrtnlabs/eslint-config";
 
 export default wrtnlabs({
-  ignores: ["eslint.config.mts", "lib/**/*"]
+  ignores: ["eslint.config.mts", "lib/**/*", "vitest.config.mts"]
 });

--- a/packages/pg-vector-selector/package.json
+++ b/packages/pg-vector-selector/package.json
@@ -38,7 +38,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc && rollup -c",
+    "build": "tsc -p ./tsconfig.build.json && rollup -c",
     "prepack": "pnpm run build",
     "lint": "eslint .",
     "format": "eslint --fix .",

--- a/packages/pg-vector-selector/package.json
+++ b/packages/pg-vector-selector/package.json
@@ -41,7 +41,8 @@
     "build": "tsc && rollup -c",
     "prepack": "pnpm run build",
     "lint": "eslint .",
-    "format": "eslint --fix ."
+    "format": "eslint --fix .",
+    "test": "vitest"
   },
   "peerDependencies": {
     "@agentica/core": "workspace:^"
@@ -57,6 +58,7 @@
     "@types/node": "^22.10.5",
     "rimraf": "^6.0.1",
     "rollup": "^4.29.1",
-    "typescript": "catalog:libs"
+    "typescript": "catalog:libs",
+    "vitest": "catalog:vite"
   }
 }

--- a/packages/pg-vector-selector/package.json
+++ b/packages/pg-vector-selector/package.json
@@ -58,6 +58,7 @@
     "@types/node": "^22.10.5",
     "rimraf": "^6.0.1",
     "rollup": "^4.29.1",
+    "type-fest": "catalog:libs",
     "typescript": "catalog:libs",
     "vitest": "catalog:vite"
   }

--- a/packages/pg-vector-selector/src/AgenticaPgVectorSelector.ts
+++ b/packages/pg-vector-selector/src/AgenticaPgVectorSelector.ts
@@ -8,6 +8,7 @@ import { functional, HttpError } from "@wrtnlabs/connector-hive-api";
 import type { IAgenticaPgVectorSelectorBootProps } from "./AgenticaPgVectorSelectorBootProps";
 
 import { Tools } from "./Tools";
+import { getRetry, groupByArray } from "./utils";
 
 function useEmbeddedContext<SchemaModel extends ILlmSchema.Model>() {
   const set = new Map<string, IApplicationConnectorRetrieval.IFilter>();
@@ -23,41 +24,6 @@ function useEmbeddedContext<SchemaModel extends ILlmSchema.Model>() {
     (ctx: AgenticaContext<SchemaModel>) =>
       set.get(JSON.stringify(ctx.operations.array)),
   ] as const;
-}
-
-function getRetry(count: number) {
-  if (count < 1) {
-    throw new Error("count should be greater than 0");
-  }
-
-  return async <T>(fn: () => Promise<T>) => {
-    let lastError: Error | null = null;
-
-    for (let i = 0; i < count; i++) {
-      try {
-        return await fn();
-      }
-      catch (e: unknown) {
-        lastError = e as Error;
-        if (i === count - 1) {
-          throw e;
-        }
-      }
-    }
-
-    if (lastError != null) {
-      throw lastError;
-    }
-    throw new Error("unreachable code");
-  };
-}
-
-function groupByArray<T>(array: T[], count: number): T[][] {
-  const grouped = [];
-  for (let i = 0; i < array.length; i += count) {
-    grouped.push(array.slice(i, i + count));
-  }
-  return grouped;
 }
 
 const retry = getRetry(3);

--- a/packages/pg-vector-selector/src/utils.test.ts
+++ b/packages/pg-vector-selector/src/utils.test.ts
@@ -1,0 +1,52 @@
+import { getRetry, groupByArray } from "./utils";
+
+describe("getRetry", () => {
+  it("should throw error when count is less than 1", () => {
+    expect(() => getRetry(0)).toThrow("count should be greater than 0");
+  });
+
+  it("should retry the function specified number of times", async () => {
+    let attempts = 0;
+    const fn = async () => {
+      attempts++;
+      if (attempts < 3) {
+        throw new Error("Failed");
+      }
+      return "success";
+    };
+
+    const retryFn = getRetry(3);
+    const result = await retryFn(fn);
+    expect(result).toBe("success");
+    expect(attempts).toBe(3);
+  });
+
+  it("should throw the last error when all retries fail", async () => {
+    const error = new Error("Failed");
+    const fn = async () => {
+      throw error;
+    };
+
+    const retryFn = getRetry(3);
+    await expect(retryFn(fn)).rejects.toThrow(error);
+  });
+});
+
+describe("groupByArray", () => {
+  it("should group array into chunks of specified size", () => {
+    const array = [1, 2, 3, 4, 5, 6];
+    const result = groupByArray(array, 2);
+    expect(result).toEqual([[1, 2], [3, 4], [5, 6]]);
+  });
+
+  it("should handle array with length not divisible by count", () => {
+    const array = [1, 2, 3, 4, 5];
+    const result = groupByArray(array, 2);
+    expect(result).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("should return empty array when input array is empty", () => {
+    const result = groupByArray([], 2);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/pg-vector-selector/src/utils.test.ts
+++ b/packages/pg-vector-selector/src/utils.test.ts
@@ -2,6 +2,7 @@ import { getRetry, groupByArray } from "./utils";
 
 describe("getRetry", () => {
   it("should throw error when count is less than 1", () => {
+    // @ts-expect-error getRetry should throw error when count is not more than 0
     expect(() => getRetry(0)).toThrow("count should be greater than 0");
   });
 
@@ -159,6 +160,7 @@ describe("groupByArray", () => {
 
   it("should throw error when count is less than 1", () => {
     const array = [1, 2, 3, 4, 5];
+    // @ts-expect-error groupByArray should throw error when count is not more than 0
     expect(() => groupByArray(array, 0)).toThrow("count should be greater than 0");
   });
 

--- a/packages/pg-vector-selector/src/utils.test.ts
+++ b/packages/pg-vector-selector/src/utils.test.ts
@@ -133,23 +133,6 @@ describe("getRetry", () => {
     const result = await retryFn(fn);
     expect(result).toBe(1e20);
   });
-
-  it("should throw error when count is NaN", () => {
-    expect(() => getRetry(Number.NaN)).toThrow("count should be greater than 0");
-    expect(() => getRetry(0 / 0)).toThrow("count should be greater than 0");
-    expect(() => getRetry(Number.parseInt("not a number"))).toThrow("count should be greater than 0");
-  });
-
-  it("should throw error when count is Infinite", () => {
-    expect(() => getRetry(Infinity)).toThrow("count should be finite");
-    expect(() => getRetry(-Infinity)).toThrow("count should be finite");
-    expect(() => getRetry(1 / 0)).toThrow("count should be finite");
-  });
-
-  it("should throw error when count is not an integer", () => {
-    expect(() => getRetry(1.5)).toThrow("count should be an integer");
-    expect(() => getRetry(2.7)).toThrow("count should be an integer");
-  });
 });
 
 describe("groupByArray", () => {
@@ -179,20 +162,6 @@ describe("groupByArray", () => {
   it("should throw error when count is less than 1", () => {
     const array = [1, 2, 3, 4, 5];
     expect(() => groupByArray(array, 0)).toThrow("count should be greater than 0");
-    expect(() => groupByArray(array, -1)).toThrow("count should be greater than 0");
-  });
-
-  it("should throw error when count is not a number", () => {
-    const array = [1, 2, 3, 4, 5];
-    expect(() => groupByArray(array, Number.NaN)).toThrow("count should be a valid number");
-    expect(() => groupByArray(array, Infinity)).toThrow("count should be finite");
-    expect(() => groupByArray(array, -Infinity)).toThrow("count should be finite");
-  });
-
-  it("should throw error when count is not an integer", () => {
-    const array = [1, 2, 3, 4, 5];
-    expect(() => groupByArray(array, 2.5)).toThrow("count should be an integer");
-    expect(() => groupByArray(array, 1.1)).toThrow("count should be an integer");
   });
 
   it("should handle array with different data types", () => {

--- a/packages/pg-vector-selector/src/utils.test.ts
+++ b/packages/pg-vector-selector/src/utils.test.ts
@@ -1,5 +1,3 @@
-import { vi } from "vitest";
-
 import { getRetry, groupByArray } from "./utils";
 
 describe("getRetry", () => {

--- a/packages/pg-vector-selector/src/utils.test.ts
+++ b/packages/pg-vector-selector/src/utils.test.ts
@@ -30,6 +30,131 @@ describe("getRetry", () => {
     const retryFn = getRetry(3);
     await expect(retryFn(fn)).rejects.toThrow(error);
   });
+
+  it("should handle noop functions", async () => {
+    const retryFn = getRetry(3);
+    const result = await retryFn(async () => {});
+    expect(result).toBeUndefined();
+  });
+
+  it("should handle non-async functions", async () => {
+    let attempts = 0;
+    const fn = () => {
+      attempts++;
+      if (attempts < 2) {
+        throw new Error("Failed");
+      }
+      return "success";
+    };
+
+    const retryFn = getRetry(3);
+    const result = await retryFn(async () => fn());
+    expect(result).toBe("success");
+    expect(attempts).toBe(2);
+  });
+
+  it("should stop retrying after successful attempt", async () => {
+    let attempts = 0;
+    const fn = async () => {
+      attempts++;
+      if (attempts === 2) {
+        return "success";
+      }
+      throw new Error("Failed");
+    };
+
+    const retryFn = getRetry(5);
+    const result = await retryFn(fn);
+    expect(result).toBe("success");
+    expect(attempts).toBe(2);
+  });
+
+  it("should handle different types of errors", async () => {
+    const retryFn = getRetry(3);
+
+    await expect(retryFn(async () => {
+      throw new TypeError("Type error");
+    })).rejects.toThrow(TypeError);
+
+    await expect(retryFn(async () => {
+      throw new RangeError("Range error");
+    })).rejects.toThrow(RangeError);
+  });
+
+  it("should handle null and undefined return values", async () => {
+    const retryFn = getRetry(2);
+
+    const nullFn = async () => null;
+    const undefinedFn = async () => undefined;
+
+    expect(await retryFn(nullFn)).toBeNull();
+    expect(await retryFn(undefinedFn)).toBeUndefined();
+  });
+
+  it("should handle floating point calculations", async () => {
+    let attempts = 0;
+    const fn = async () => {
+      attempts++;
+      if (attempts < 2) {
+        throw new Error("Failed");
+      }
+      return 3.14159;
+    };
+
+    const retryFn = getRetry(3);
+    const result = await retryFn(fn);
+    expect(result).toBeCloseTo(3.14159);
+    expect(attempts).toBe(2);
+  });
+
+  it("should handle mathematical operations with floating points", async () => {
+    let attempts = 0;
+    const fn = async () => {
+      attempts++;
+      if (attempts < 2) {
+        throw new Error("Failed");
+      }
+      return 0.1 + 0.2; // Known floating point precision issue
+    };
+
+    const retryFn = getRetry(3);
+    const result = await retryFn(fn);
+    expect(result).toBeCloseTo(0.3);
+    expect(attempts).toBe(2);
+  });
+
+  it("should handle very small floating point numbers", async () => {
+    const retryFn = getRetry(2);
+    const fn = async () => 0.0000001;
+
+    const result = await retryFn(fn);
+    expect(result).toBeCloseTo(0.0000001);
+  });
+
+  it("should handle very large floating point numbers", async () => {
+    const retryFn = getRetry(2);
+    const fn = async () => 1e20;
+
+    const result = await retryFn(fn);
+    expect(result).toBe(1e20);
+  });
+
+  it("should throw error when count is NaN", () => {
+    expect(() => getRetry(Number.NaN)).toThrow("count should be greater than 0");
+    expect(() => getRetry(0 / 0)).toThrow("count should be greater than 0");
+    expect(() => getRetry(Number.parseInt("not a number"))).toThrow("count should be greater than 0");
+  });
+
+  it("should throw error when count is Infinite", () => {
+    expect(() => getRetry(Infinity)).toThrow("count should be finite");
+    expect(() => getRetry(-Infinity)).toThrow("count should be finite");
+    expect(() => getRetry(1 / 0)).toThrow("count should be finite");
+  });
+
+  it("should throw error when count is not an integer", () => {
+    expect(() => getRetry(1.5)).toThrow("count should be an integer");
+    expect(() => getRetry(2.7)).toThrow("count should be an integer");
+  });
 });
 
 describe("groupByArray", () => {

--- a/packages/pg-vector-selector/src/utils.test.ts
+++ b/packages/pg-vector-selector/src/utils.test.ts
@@ -170,7 +170,7 @@ describe("groupByArray", () => {
     expect(result).toEqual([]);
   });
 
-  it("should return 2dim-array with only one original array when the array length is less than division number", () => {
+  it("should handle count larger than array length", () => {
     const array = [1];
     const result = groupByArray(array, 2);
     expect(result).toEqual([[1]]);
@@ -212,11 +212,5 @@ describe("groupByArray", () => {
     expect(result.length).toBe(10);
     expect(result[0]?.length).toBe(100);
     expect(result[9]?.length).toBe(100);
-  });
-
-  it("should handle count larger than array length", () => {
-    const array = [1, 2, 3];
-    const result = groupByArray(array, 5);
-    expect(result).toEqual([[1, 2, 3]]);
   });
 });

--- a/packages/pg-vector-selector/src/utils.ts
+++ b/packages/pg-vector-selector/src/utils.ts
@@ -1,4 +1,8 @@
-import type { NonNegativeInteger } from "type-fest";
+import type { GreaterThan, Integer } from "type-fest";
+
+/** type function to check if a number is greater than 0 */
+type GreaterThanZeroInteger<T extends number> = GreaterThan<Integer<T>, 0> extends true ? T : never;
+
 /**
  * This function is used to get a retry function.
  *
@@ -12,7 +16,7 @@ import type { NonNegativeInteger } from "type-fest";
  * @throws {TypeError} If the count is not a number, or if the count is not a finite number, or if the count is not an integer, or if the count is less than 1.
  * @throws {Error} If the function fails to return a value after the specified number of retries.
  */
-export function getRetry<TCount extends number>(count: NonNegativeInteger<TCount>) {
+export function getRetry<TCount extends number>(count: GreaterThanZeroInteger<TCount>) {
   if (count < 1) {
     throw new Error("count should be greater than 0");
   }
@@ -48,7 +52,7 @@ export function getRetry<TCount extends number>(count: NonNegativeInteger<TCount
  * @param count - The number of elements in each group.
  * @returns A 2-dimensional array.
  */
-export function groupByArray<T, TCount extends number>(array: T[], count: NonNegativeInteger<TCount>): T[][] {
+export function groupByArray<T, TCount extends number>(array: T[], count: GreaterThanZeroInteger<TCount>): T[][] {
   if (count < 1) {
     throw new Error("count should be greater than 0");
   }

--- a/packages/pg-vector-selector/src/utils.ts
+++ b/packages/pg-vector-selector/src/utils.ts
@@ -1,27 +1,46 @@
+/**
+ * This function is used to get a retry function.
+ *
+ * It will throw an error if the count is not a number,
+ * or if the count is not a finite number,
+ * or if the count is not an integer,
+ * or if the count is less than 1.
+ *
+ * @param count - The number of times to retry the function.
+ * @returns A retry function.
+ * @throws {TypeError} If the count is not a number, or if the count is not a finite number, or if the count is not an integer, or if the count is less than 1.
+ * @throws {Error} If the function fails to return a value after the specified number of retries.
+ */
 export function getRetry(count: number) {
+  if (!Number.isFinite(count)) {
+    if (Number.isNaN(count)) {
+      throw new TypeError("count should be greater than 0");
+    }
+    throw new Error("count should be finite");
+  }
+  if (!Number.isInteger(count)) {
+    throw new TypeError("count should be an integer");
+  }
   if (count < 1) {
     throw new Error("count should be greater than 0");
   }
 
   return async <T>(fn: () => Promise<T>) => {
-    let lastError: Error | null = null;
+    let lastError: unknown = null;
 
     for (let i = 0; i < count; i++) {
       try {
         return await fn();
       }
       catch (e: unknown) {
-        lastError = e as Error;
+        lastError = e;
         if (i === count - 1) {
           throw e;
         }
       }
     }
-
-    if (lastError != null) {
-      throw lastError;
-    }
-    throw new Error("unreachable code");
+    // count should be greater than 0.
+    throw lastError;
   };
 }
 

--- a/packages/pg-vector-selector/src/utils.ts
+++ b/packages/pg-vector-selector/src/utils.ts
@@ -44,7 +44,40 @@ export function getRetry(count: number) {
   };
 }
 
+/**
+ * This function is used to group an array into a 2-dimensional array.
+ *
+ * It will throw an error if the count is not a number,
+ * or if the count is not a finite number,
+ * or if the count is not an integer,
+ * or if the count is less than 1.
+ *
+ * @param array - The array to group.
+ * @param count - The number of elements in each group.
+ * @returns A 2-dimensional array.
+ */
 export function groupByArray<T>(array: T[], count: number): T[][] {
+  if (!Number.isFinite(count)) {
+    if (Number.isNaN(count)) {
+      throw new TypeError("count should be a valid number");
+    }
+    throw new Error("count should be finite");
+  }
+  if (!Number.isInteger(count)) {
+    throw new TypeError("count should be an integer");
+  }
+  if (count < 1) {
+    throw new Error("count should be greater than 0");
+  }
+
+  if (array.length === 0) {
+    return [];
+  }
+
+  if (array.length < count) {
+    return [array];
+  }
+
   const grouped = [];
   for (let i = 0; i < array.length; i += count) {
     grouped.push(array.slice(i, i + count));

--- a/packages/pg-vector-selector/src/utils.ts
+++ b/packages/pg-vector-selector/src/utils.ts
@@ -1,3 +1,4 @@
+import type { NonNegativeInteger } from "type-fest";
 /**
  * This function is used to get a retry function.
  *
@@ -11,16 +12,7 @@
  * @throws {TypeError} If the count is not a number, or if the count is not a finite number, or if the count is not an integer, or if the count is less than 1.
  * @throws {Error} If the function fails to return a value after the specified number of retries.
  */
-export function getRetry(count: number) {
-  if (!Number.isFinite(count)) {
-    if (Number.isNaN(count)) {
-      throw new TypeError("count should be greater than 0");
-    }
-    throw new Error("count should be finite");
-  }
-  if (!Number.isInteger(count)) {
-    throw new TypeError("count should be an integer");
-  }
+export function getRetry<TCount extends number>(count: NonNegativeInteger<TCount>) {
   if (count < 1) {
     throw new Error("count should be greater than 0");
   }
@@ -56,16 +48,7 @@ export function getRetry(count: number) {
  * @param count - The number of elements in each group.
  * @returns A 2-dimensional array.
  */
-export function groupByArray<T>(array: T[], count: number): T[][] {
-  if (!Number.isFinite(count)) {
-    if (Number.isNaN(count)) {
-      throw new TypeError("count should be a valid number");
-    }
-    throw new Error("count should be finite");
-  }
-  if (!Number.isInteger(count)) {
-    throw new TypeError("count should be an integer");
-  }
+export function groupByArray<T, TCount extends number>(array: T[], count: NonNegativeInteger<TCount>): T[][] {
   if (count < 1) {
     throw new Error("count should be greater than 0");
   }

--- a/packages/pg-vector-selector/src/utils.ts
+++ b/packages/pg-vector-selector/src/utils.ts
@@ -1,0 +1,34 @@
+export function getRetry(count: number) {
+  if (count < 1) {
+    throw new Error("count should be greater than 0");
+  }
+
+  return async <T>(fn: () => Promise<T>) => {
+    let lastError: Error | null = null;
+
+    for (let i = 0; i < count; i++) {
+      try {
+        return await fn();
+      }
+      catch (e: unknown) {
+        lastError = e as Error;
+        if (i === count - 1) {
+          throw e;
+        }
+      }
+    }
+
+    if (lastError != null) {
+      throw lastError;
+    }
+    throw new Error("unreachable code");
+  };
+}
+
+export function groupByArray<T>(array: T[], count: number): T[][] {
+  const grouped = [];
+  for (let i = 0; i < array.length; i += count) {
+    grouped.push(array.slice(i, i + count));
+  }
+  return grouped;
+}

--- a/packages/pg-vector-selector/tsconfig.build.json
+++ b/packages/pg-vector-selector/tsconfig.build.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   // exclude .test.ts files from build
   "exclude": [
-    "**/*.test.ts",
-  ],
+    "**/*.test.ts"
+  ]
 }

--- a/packages/pg-vector-selector/tsconfig.build.json
+++ b/packages/pg-vector-selector/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  // exclude .test.ts files from build
+  "exclude": [
+    "**/*.test.ts",
+  ],
+}

--- a/packages/pg-vector-selector/tsconfig.json
+++ b/packages/pg-vector-selector/tsconfig.json
@@ -26,6 +26,12 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
     "module": "commonjs", /* Specify what module code is generated. */// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "types": ["vitest/globals"], /* Specify type package names to be included without being referenced in a source file. */
     "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true,
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
@@ -42,12 +48,6 @@
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     "noUnusedLocals": true, /* Enable error reporting when local variables aren't read. */
     "noUnusedParameters": true, /* Raise an error when a function parameter isn't read. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/packages/pg-vector-selector/vitest.config.mts
+++ b/packages/pg-vector-selector/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ["**/node_modules/**", "**/lib/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,10 @@ catalogs:
     typia:
       specifier: ^8.1.1
       version: 8.1.1
+  vite:
+    vitest:
+      specifier: ^3.0.9
+      version: 3.0.9
 
 overrides:
   '@types/react': 19.0.0
@@ -273,7 +277,7 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.8.2)
       vitest:
-        specifier: ^3.0.9
+        specifier: catalog:vite
         version: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.25)(lightningcss@1.29.2)(msw@2.7.3(@types/node@20.17.25)(typescript@5.8.2))(terser@5.39.0)
     optionalDependencies:
       prettier:
@@ -365,6 +369,9 @@ importers:
       typescript:
         specifier: catalog:libs
         version: 5.8.2
+      vitest:
+        specifier: catalog:vite
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.9)(lightningcss@1.29.2)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.39.0)
 
   packages/rpc:
     dependencies:
@@ -9657,7 +9664,6 @@ snapshots:
     optionalDependencies:
       msw: 2.7.3(@types/node@22.13.9)(typescript@5.8.2)
       vite: 5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0)
-    optional: true
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -15095,7 +15101,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-    optional: true
 
   vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0):
     dependencies:
@@ -15190,7 +15195,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-    optional: true
 
   vscode-jsonrpc@8.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     openai:
       specifier: ^4.80.0
       version: 4.89.0
+    type-fest:
+      specifier: ^4.37.0
+      version: 4.37.0
     typescript:
       specifier: ~5.8.2
       version: 5.8.2
@@ -265,7 +268,7 @@ importers:
         specifier: catalog:typia
         version: 3.3.0
       type-fest:
-        specifier: ^4.37.0
+        specifier: catalog:libs
         version: 4.37.0
       typescript:
         specifier: catalog:libs
@@ -366,6 +369,9 @@ importers:
       rollup:
         specifier: ^4.29.1
         version: 4.36.0
+      type-fest:
+        specifier: catalog:libs
+        version: 4.37.0
       typescript:
         specifier: catalog:libs
         version: 5.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ catalogs:
     ts-patch: ^3.3.0
     typia: ^8.1.1
 
+  vite:
+    vitest: ^3.0.9
 onlyBuiltDependencies:
   - core-js
   - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,9 @@ catalogs:
   libs:
     "@samchon/openapi": ^3.2.3
     openai: ^4.80.0
-    typescript: ~5.8.2
+    type-fest: ^4.37.0
 
+    typescript: ~5.8.2
   typia:
     "@ryoppippi/unplugin-typia": ^2.1.3
     ts-patch: ^3.3.0

--- a/test/src/features/test_benchmark_call_pg_vector_selector.ts
+++ b/test/src/features/test_benchmark_call_pg_vector_selector.ts
@@ -13,7 +13,7 @@ import OpenAI from "openai";
 
 import { TestGlobal } from "../TestGlobal";
 
-export async function test_benchmark_calls_pg_vector_selector(): Promise<
+export async function test_benchmark_call_pg_vector_selector(): Promise<
   void | false
 > {
   if (TestGlobal.chatgptApiKey.length === 0) {


### PR DESCRIPTION
This pull request includes several updates across multiple files to integrate the `vitest` testing framework and improve the code structure by moving utility functions to a separate file. The most important changes include updating dependencies, modifying configurations, and adding new utility functions with corresponding tests.

### Dependency and Configuration Updates:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L72-R72): Updated the `vitest` dependency to use `catalog:vite`.
* [`packages/pg-vector-selector/package.json`](diffhunk://#diff-17c97c54e8f9e9e170b125f77d0288d568fcbc648384108b88347b62b6f5e09fL44-R45): Added `vitest` as a dependency and a new `test` script to run `vitest`. [[1]](diffhunk://#diff-17c97c54e8f9e9e170b125f77d0288d568fcbc648384108b88347b62b6f5e09fL44-R45) [[2]](diffhunk://#diff-17c97c54e8f9e9e170b125f77d0288d568fcbc648384108b88347b62b6f5e09fL60-R62)
* [`packages/pg-vector-selector/tsconfig.json`](diffhunk://#diff-f1ce2032c0fe72d1155fe6fe4b4247761b1d63cb6efd2158a913ecb4bd2dcdb1R29-R34): Included `vitest/globals` in the `types` array for type checking. [[1]](diffhunk://#diff-f1ce2032c0fe72d1155fe6fe4b4247761b1d63cb6efd2158a913ecb4bd2dcdb1R29-R34) [[2]](diffhunk://#diff-f1ce2032c0fe72d1155fe6fe4b4247761b1d63cb6efd2158a913ecb4bd2dcdb1L45-L50)
* [`packages/pg-vector-selector/vitest.config.mts`](diffhunk://#diff-9035afd1cc2473be52bc084524effcefbc9be6c035ac7d1d78d05064dc5ef68fR1-R8): Added a new configuration file for `vitest`.
* `pnpm-lock.yaml` and `pnpm-workspace.yaml`: Updated to include `vitest` under the `vite` catalog. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR28-R31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL276-R280) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR372-R374) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9660) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15098) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15193) [[7]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR17-R18)

### Code Refactoring:

* [`packages/pg-vector-selector/src/AgenticaPgVectorSelector.ts`](diffhunk://#diff-253fab8a8e7cdc9a558701d95d614c76132bbe5f7a642a47cfff07a5a02cd068R11): Removed the `getRetry` and `groupByArray` functions and imported them from the new `utils` file. [[1]](diffhunk://#diff-253fab8a8e7cdc9a558701d95d614c76132bbe5f7a642a47cfff07a5a02cd068R11) [[2]](diffhunk://#diff-253fab8a8e7cdc9a558701d95d614c76132bbe5f7a642a47cfff07a5a02cd068L28-L62)
* [`packages/pg-vector-selector/src/utils.ts`](diffhunk://#diff-70bdfa65a39a3686de85736e49720c573b34c8e31d914f46e95342d02964051cR1-R34): Added new `getRetry` and `groupByArray` utility functions.

### Testing:

* [`packages/pg-vector-selector/src/utils.test.ts`](diffhunk://#diff-39108708785b93af0642a0b6d5e179e3934c96884ca44d64b6cdad9ba6e41a6dR1-R52): Added tests for the `getRetry` and `groupByArray` utility functions to ensure their correctness.

### Linting:

* [`packages/pg-vector-selector/eslint.config.mts`](diffhunk://#diff-bc8654ab837d19c153fab6c7ec80089bf3d2c19475b81023efe0e60dc619889bL4-R4): Updated linting ignores to include `vitest.config.mts`.

### Minor Fixes:

* [`test/src/features/test_benchmark_call_pg_vector_selector.ts`](diffhunk://#diff-4bd10fbea8517c5ec9a24a9d9b29ad60e53818ea75a4b636476bfaf6fd66c8feL16-R16): Corrected the function name from `test_benchmark_calls_pg_vector_selector` to `test_benchmark_call_pg_vector_selector`.