### PR TITLE
Prepare dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    package-manager: pnpm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 25
+    versioning-strategy: increase
+    allow:
+      - dependency-name: "@ryoppippi/unplugin-typia"
+      - dependency-name: "@samchon/openapi"
+      - dependency-name: typia
+      - dependency-name: typescript
+      - dependency-name: ts-patch
+      - dependency-name: openai
+    groups:
+      typia:
+        patterns:
+          - "@ryoppippi/unplugin-typia"
+          - "@samchon/openapi"
+          - typia
+      typescript:
+        patterns:
+          - typescript
+          - ts-patch
+      vendor:
+        patterns:
+          - openai

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@agentica/core": "workspace:^",
-    "@samchon/openapi": "catalog:libs",
+    "@samchon/openapi": "catalog:typia",
     "openai": "catalog:libs",
     "tstl": "^3.0.0",
     "typia": "catalog:typia"
@@ -58,8 +58,8 @@
     "@types/node": "^22.13.4",
     "rimraf": "^6.0.1",
     "rollup": "^4.34.8",
-    "ts-patch": "catalog:typia",
+    "ts-patch": "catalog:typescript",
     "typedoc": "^0.27.7",
-    "typescript": "catalog:libs"
+    "typescript": "catalog:typescript"
   }
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -50,7 +50,7 @@
     "@agentica/core": "workspace:^",
     "@mui/icons-material": "^6.4.0",
     "@mui/material": "^6.4.0",
-    "@samchon/openapi": "catalog:libs",
+    "@samchon/openapi": "catalog:typia",
     "html-to-image": "^1.11.13",
     "openai": "catalog:libs",
     "react-markdown": "^9.0.3",
@@ -85,8 +85,8 @@
     "react-mui-fileuploader": "^0.5.2",
     "rimraf": "^6.0.1",
     "rollup": "^4.24.2",
-    "ts-patch": "catalog:typia",
-    "typescript": "catalog:libs",
+    "ts-patch": "catalog:typescript",
+    "typescript": "catalog:typescript",
     "typescript-eslint": "^8.10.0",
     "vite": "^5.4.9"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,9 +64,9 @@
     "publint": "^0.3.9",
     "std-env": "^3.8.1",
     "ts-node": "^10.9.2",
-    "ts-patch": "catalog:typia",
+    "ts-patch": "catalog:typescript",
     "type-fest": "catalog:libs",
-    "typescript": "catalog:libs",
+    "typescript": "catalog:typescript",
     "typia": "catalog:typia",
     "unbuild": "^3.5.0",
     "vitest": "catalog:vite"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,12 +48,12 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=3.2.2 <4.0.0",
+    "@samchon/openapi": ">=4.0.0 <5.0.0",
     "openai": ">=4.80.0",
-    "typia": ">=8.1.0 <9.0.0"
+    "typia": ">=9.0.1 <10.0.0"
   },
   "dependencies": {
-    "@samchon/openapi": "catalog:libs",
+    "@samchon/openapi": "catalog:typia",
     "typia": "catalog:typia",
     "uuid": "^11.0.4"
   },
@@ -67,8 +67,8 @@
     "rimraf": "^6.0.1",
     "rollup": "^4.34.8",
     "ts-node": "^10.9.2",
-    "ts-patch": "catalog:typia",
+    "ts-patch": "catalog:typescript",
     "typedoc": "^0.27.7",
-    "typescript": "catalog:libs"
+    "typescript": "catalog:typescript"
   }
 }

--- a/packages/pg-vector-selector/package.json
+++ b/packages/pg-vector-selector/package.json
@@ -54,12 +54,12 @@
     "@agentica/core": "workspace:^",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.1",
-    "@samchon/openapi": "catalog:libs",
+    "@samchon/openapi": "catalog:typia",
     "@types/node": "^22.10.5",
     "rimraf": "^6.0.1",
     "rollup": "^4.29.1",
     "type-fest": "catalog:libs",
-    "typescript": "catalog:libs",
+    "typescript": "catalog:typescript",
     "vitest": "catalog:vite"
   }
 }

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@agentica/core": "workspace:^",
-    "@samchon/openapi": "catalog:libs",
+    "@samchon/openapi": "catalog:typia",
     "typia": "catalog:typia"
   },
   "devDependencies": {
@@ -57,8 +57,8 @@
     "@types/node": "^22.13.4",
     "rimraf": "^6.0.1",
     "rollup": "^4.34.8",
-    "ts-patch": "catalog:typia",
+    "ts-patch": "catalog:typescript",
     "typedoc": "^0.27.7",
-    "typescript": "catalog:libs"
+    "typescript": "catalog:typescript"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,25 +6,26 @@ settings:
 
 catalogs:
   libs:
-    '@samchon/openapi':
-      specifier: ^3.2.3
-      version: 3.2.3
     openai:
       specifier: ^4.80.0
       version: 4.89.0
     type-fest:
       specifier: ^4.37.0
       version: 4.37.0
+  typescript:
+    ts-patch:
+      specifier: ^3.3.0
+      version: 3.3.0
     typescript:
       specifier: ~5.8.2
       version: 5.8.2
   typia:
     '@ryoppippi/unplugin-typia':
       specifier: ^2.1.3
-      version: 2.1.3
-    ts-patch:
-      specifier: ^3.3.0
-      version: 3.3.0
+      version: 2.1.4
+    '@samchon/openapi':
+      specifier: ^3.2.3
+      version: 3.2.3
     typia:
       specifier: ^8.1.1
       version: 8.1.1
@@ -71,7 +72,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@samchon/openapi':
-        specifier: catalog:libs
+        specifier: catalog:typia
         version: 3.2.3
       openai:
         specifier: catalog:libs
@@ -99,13 +100,13 @@ importers:
         specifier: ^4.34.8
         version: 4.36.0
       ts-patch:
-        specifier: catalog:typia
+        specifier: catalog:typescript
         version: 3.3.0
       typedoc:
         specifier: ^0.27.7
         version: 0.27.9(typescript@5.8.2)
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
 
   packages/chat:
@@ -120,7 +121,7 @@ importers:
         specifier: ^6.4.0
         version: 6.4.8(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@samchon/openapi':
-        specifier: catalog:libs
+        specifier: catalog:typia
         version: 3.2.3
       html-to-image:
         specifier: ^1.11.13
@@ -158,7 +159,7 @@ importers:
         version: 12.1.2(rollup@4.36.0)(tslib@2.8.1)(typescript@5.8.2)
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
       '@samchon/shopping-api':
         specifier: ^0.16.0
         version: 0.16.0(@samchon/openapi@3.2.3)(typescript@5.8.2)
@@ -217,10 +218,10 @@ importers:
         specifier: ^4.24.2
         version: 4.36.0
       ts-patch:
-        specifier: catalog:typia
+        specifier: catalog:typescript
         version: 3.3.0
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
       typescript-eslint:
         specifier: ^8.10.0
@@ -239,7 +240,7 @@ importers:
         version: 0.10.0
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@4.0.0)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))
       '@types/node':
         specifier: ^20.14.8
         version: 20.17.25
@@ -265,17 +266,17 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.17.25)(typescript@5.8.2)
       ts-patch:
-        specifier: catalog:typia
+        specifier: catalog:typescript
         version: 3.3.0
       type-fest:
         specifier: catalog:libs
         version: 4.37.0
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
       typia:
         specifier: catalog:typia
-        version: 8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2)
+        version: 8.1.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
       unbuild:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.8.2)
@@ -290,7 +291,7 @@ importers:
   packages/core:
     dependencies:
       '@samchon/openapi':
-        specifier: catalog:libs
+        specifier: catalog:typia
         version: 3.2.3
       typia:
         specifier: catalog:typia
@@ -327,13 +328,13 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.13.9)(typescript@5.8.2)
       ts-patch:
-        specifier: catalog:typia
+        specifier: catalog:typescript
         version: 3.3.0
       typedoc:
         specifier: ^0.27.7
         version: 0.27.9(typescript@5.8.2)
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
 
   packages/create-agentica:
@@ -358,7 +359,7 @@ importers:
         specifier: ^12.1.1
         version: 12.1.2(rollup@4.36.0)(tslib@2.8.1)(typescript@5.8.2)
       '@samchon/openapi':
-        specifier: catalog:libs
+        specifier: catalog:typia
         version: 3.2.3
       '@types/node':
         specifier: ^22.10.5
@@ -373,7 +374,7 @@ importers:
         specifier: catalog:libs
         version: 4.37.0
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
       vitest:
         specifier: catalog:vite
@@ -385,7 +386,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@samchon/openapi':
-        specifier: catalog:libs
+        specifier: catalog:typia
         version: 3.2.3
       typia:
         specifier: catalog:typia
@@ -410,13 +411,13 @@ importers:
         specifier: ^4.34.8
         version: 4.36.0
       ts-patch:
-        specifier: catalog:typia
+        specifier: catalog:typescript
         version: 3.3.0
       typedoc:
         specifier: ^0.27.7
         version: 0.27.9(typescript@5.8.2)
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
 
   test:
@@ -434,10 +435,10 @@ importers:
         specifier: workspace:^
         version: link:../packages/rpc
       '@nestia/e2e':
-        specifier: ^0.8.2
-        version: 0.8.3
+        specifier: ^6.0.1
+        version: 6.0.1
       '@samchon/openapi':
-        specifier: catalog:libs
+        specifier: catalog:typia
         version: 3.2.3
       '@samchon/shopping-api':
         specifier: ^0.16.0
@@ -468,10 +469,10 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.13.9)(typescript@5.8.2)
       ts-patch:
-        specifier: catalog:typia
+        specifier: catalog:typescript
         version: 3.3.0
       typescript:
-        specifier: catalog:libs
+        specifier: catalog:typescript
         version: 5.8.2
 
   website:
@@ -1787,6 +1788,9 @@ packages:
   '@nestia/e2e@0.8.3':
     resolution: {integrity: sha512-SPWseU+5suAx/ce27/HEUZ/pHaN0sMX9Isc7coswBh4oJrsb/tDo9CJrCRNCpE0oOQLOiX8rvvYqwlOBZuFluw==}
 
+  '@nestia/e2e@6.0.1':
+    resolution: {integrity: sha512-eFvAxzgEmS3TpQhOWgfA7KWTCzPRZNLwmvFlblnRkJG3zenETYq7D/NBk3AFq0AlBVdnEQWTf0B/87hbancEsQ==}
+
   '@nestia/fetcher@5.0.0':
     resolution: {integrity: sha512-tKmypxmmHPagOZUsGcUaU08gZxXEVsoaHFfcx/SaFIEuIpsejKq1VXk9/hNriUDR7HWmYkcbNrMlqo+SM9cwfA==}
     peerDependencies:
@@ -2404,10 +2408,10 @@ packages:
   '@rushstack/eslint-patch@1.11.0':
     resolution: {integrity: sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==}
 
-  '@ryoppippi/unplugin-typia@2.1.3':
-    resolution: {integrity: sha512-HO3RXkD78f0o6uR7ZWPtwjAjEV8Zne3cE4b/K76sb0+6KKhcQ+aw2UFmHzGcM9deztCj4ZkHOlF/26jYWi1xsw==}
+  '@ryoppippi/unplugin-typia@2.1.4':
+    resolution: {integrity: sha512-pZtB5YhX0Egm4agc1gOn11IQiR4NnCmwvaea9kbwBImsCpR84gGayenzFDIJxkzv0U9iEBxZGUojuKnuzfpejg==}
     peerDependencies:
-      svelte: ^5.0.0
+      svelte: ^5.25.2
       typescript: '>=4.8.0 <5.9.0'
       typia: '>=8.0.0 <9.0.0'
       vite: '>=3.0.0'
@@ -2419,6 +2423,9 @@ packages:
 
   '@samchon/openapi@3.2.3':
     resolution: {integrity: sha512-CQVa92i3hvfZftd6mULs13/WRib5a5/5qfEH/L6e5gjSSHIXrKMmwVPawi447F/bQiEd4EPE+dPmGU3lvEsVqw==}
+
+  '@samchon/openapi@4.0.0':
+    resolution: {integrity: sha512-fzji+KTrLqb3rD6RZID7N1cTN7aDwd0KAq0fP4rl2p1dHEy3uybqS7bP9BjMWP10k0DvFaS+P+g8+a/PA0FyZw==}
 
   '@samchon/shopping-api@0.16.0':
     resolution: {integrity: sha512-S51v40tJNW525XSw6h4vxuKWazAFVpMxtm0VoTfb1d6QJu0j44oQ7C8juAKRJ3WtumMmMCAIPWaXSjiO6tfYGg==}
@@ -8525,6 +8532,8 @@ snapshots:
 
   '@nestia/e2e@0.8.3': {}
 
+  '@nestia/e2e@6.0.1': {}
+
   '@nestia/fetcher@5.0.0(typescript@5.8.2)':
     dependencies:
       '@samchon/openapi': 3.2.3
@@ -9051,26 +9060,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@ryoppippi/unplugin-typia@2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))':
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
-      consola: 3.4.2
-      defu: 6.1.4
-      diff-match-patch-es: 1.0.1
-      find-cache-dir: 5.0.0
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      pkg-types: 2.1.0
-      type-fest: 4.37.0
-      typescript: 5.8.2
-      typia: 8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2)
-      unplugin: 2.2.2
-    optionalDependencies:
-      vite: 5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0)
-    transitivePeerDependencies:
-      - rollup
-
-  '@ryoppippi/unplugin-typia@2.1.3(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
+  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2))(vite@5.4.14(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
       consola: 3.4.2
@@ -9089,7 +9079,28 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
+  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@4.0.0)(typescript@5.8.2))(vite@5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0))':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
+      consola: 3.4.2
+      defu: 6.1.4
+      diff-match-patch-es: 1.0.1
+      find-cache-dir: 5.0.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      pkg-types: 2.1.0
+      type-fest: 4.37.0
+      typescript: 5.8.2
+      typia: 8.1.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
+      unplugin: 2.2.2
+    optionalDependencies:
+      vite: 5.4.14(@types/node@20.17.25)(lightningcss@1.29.2)(terser@5.39.0)
+    transitivePeerDependencies:
+      - rollup
+
   '@samchon/openapi@3.2.3': {}
+
+  '@samchon/openapi@4.0.0': {}
 
   '@samchon/shopping-api@0.16.0(@samchon/openapi@3.2.3)(typescript@5.8.2)':
     dependencies:
@@ -14847,6 +14858,16 @@ snapshots:
   typia@8.1.1(@samchon/openapi@3.2.3)(typescript@5.8.2):
     dependencies:
       '@samchon/openapi': 3.2.3
+      commander: 10.0.1
+      comment-json: 4.2.5
+      inquirer: 8.2.6
+      package-manager-detector: 0.2.11
+      randexp: 0.5.3
+      typescript: 5.8.2
+
+  typia@8.1.1(@samchon/openapi@4.0.0)(typescript@5.8.2):
+    dependencies:
+      '@samchon/openapi': 4.0.0
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,18 +5,18 @@ packages:
 
 catalogs:
   libs:
-    "@samchon/openapi": ^3.2.3
     openai: ^4.80.0
     type-fest: ^4.37.0
-
+  typescript:
+    ts-patch: ^3.3.0
     typescript: ~5.8.2
   typia:
     "@ryoppippi/unplugin-typia": ^2.1.3
-    ts-patch: ^3.3.0
+    "@samchon/openapi": ^3.2.3
     typia: ^8.1.1
-
   vite:
     vitest: ^3.0.9
+
 onlyBuiltDependencies:
   - core-js
   - esbuild

--- a/test/package.json
+++ b/test/package.json
@@ -18,8 +18,8 @@
     "@agentica/core": "workspace:^",
     "@agentica/pg-vector-selector": "workspace:^",
     "@agentica/rpc": "workspace:^",
-    "@nestia/e2e": "^0.8.2",
-    "@samchon/openapi": "catalog:libs",
+    "@nestia/e2e": "^6.0.1",
+    "@samchon/openapi": "catalog:typia",
     "@samchon/shopping-api": "^0.16.0",
     "chalk": "4.1.2",
     "dotenv": "^16.4.7",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "ts-node": "^10.9.2",
-    "ts-patch": "catalog:typia",
-    "typescript": "catalog:libs"
+    "ts-patch": "catalog:typescript",
+    "typescript": "catalog:typescript"
   }
 }

--- a/test/src/features/test_base_work_describe.ts
+++ b/test/src/features/test_base_work_describe.ts
@@ -42,7 +42,7 @@ export async function test_base_work_describe(): Promise<void | false> {
   const calculatorController: IAgenticaController<"chatgpt"> = {
     protocol: "class",
     name: "calculator",
-    application: typia.llm.applicationOfValidate<Calculator, "chatgpt">(),
+    application: typia.llm.application<Calculator, "chatgpt">(),
     execute: new Calculator(),
   };
 


### PR DESCRIPTION
https://github.blog/changelog/2025-02-04-dependabot-now-supports-pnpm-workspace-catalogs-ga/

Github says dependabot is supporting pnpm catalog.

Let's test it.

---------------

This pull request includes updates to the dependency management and versioning strategy across multiple packages. The changes primarily focus on updating the dependencies and ensuring consistency in the package catalog references.

Dependency management updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R29): Added a new configuration for dependabot to manage npm dependencies using pnpm, with specific groups for `typia`, `typescript`, and `vendor` dependencies.

Catalog reference updates:

* [`packages/benchmark/package.json`](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1L50-R50): Updated catalog references for `@samchon/openapi`, `ts-patch`, and `typescript` dependencies. [[1]](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1L50-R50) [[2]](diffhunk://#diff-03d34ead8faa24fcf5b6d74b52eaf57db4400f375b60698e3f5024e28b29b0e1L61-R63)
* [`packages/chat/package.json`](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL53-R53): Updated catalog references for `@samchon/openapi`, `ts-patch`, and `typescript` dependencies. [[1]](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL53-R53) [[2]](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL88-R89)
* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L67-R69): Updated catalog references for `ts-patch` and `typescript` dependencies.
* [`packages/core/package.json`](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L51-R56): Updated catalog references for `@samchon/openapi`, `ts-patch`, and `typescript` dependencies, and updated peer dependency versions. [[1]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L51-R56) [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L70-R72)

Lockfile updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9-R28): Updated various catalog references and dependency versions to reflect the changes in the package.json files. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL74-R75) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL102-R109) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL123-R124) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL161-R162) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL220-R224) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL242-R243) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL268-R279) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL293-R294) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL330-R337) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL361-R362) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL376-R377) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL388-R389) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL413-R420) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL437-R441) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL471-R475) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1791-R1793) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2407-R2414) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2427-R2429) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8535-R8536) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9054-R9063) [[22]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9069-R9082)