### PR TITLE
test(rpc): check websocket's serialization

### DIFF
--- a/packages/rpc/src/AgenticaRpcService.ts
+++ b/packages/rpc/src/AgenticaRpcService.ts
@@ -78,7 +78,7 @@ implements IAgenticaRpcService<Model> {
       listener.cancel!(evt.toJSON()).catch(() => {});
     });
     agent.on("call", async (evt) => {
-      const args: object | null | undefined = await listener.call!(
+      const args: object | null | undefined | void = await listener.call!(
         evt.toJSON(),
       );
       if (args != null) {

--- a/packages/rpc/src/IAgenticaRpcListener.ts
+++ b/packages/rpc/src/IAgenticaRpcListener.ts
@@ -105,7 +105,7 @@ export interface IAgenticaRpcListener {
    * @param evt Event of a function calling
    * @return New arguments if you want to modify, otherwise null or undefined
    */
-  call?: (evt: IAgenticaEventJson.ICall) => Promise<object | null | undefined>;
+  call?: (evt: IAgenticaEventJson.ICall) => Promise<object | null | void | undefined>;
 
   /**
    * Executition of a function.

--- a/test/src/features/rpc/test_rpc_websocket_initialize.ts
+++ b/test/src/features/rpc/test_rpc_websocket_initialize.ts
@@ -1,0 +1,85 @@
+import type { IAgenticaEventJson } from "@agentica/core";
+import type {
+  IAgenticaRpcListener,
+  IAgenticaRpcService,
+} from "@agentica/rpc";
+import type { Driver } from "tgrid";
+
+import { Agentica } from "@agentica/core";
+import {
+  AgenticaRpcService,
+} from "@agentica/rpc";
+import { TestValidator } from "@nestia/e2e";
+import OpenAI from "openai";
+import { WebSocketConnector, WebSocketServer } from "tgrid";
+import { randint } from "tstl";
+
+import { TestGlobal } from "../../TestGlobal";
+
+export async function test_rpc_websocket_initialize(): Promise<void | false> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+
+  const port: number = randint(30_001, 65_001);
+  const server: WebSocketServer<
+    null,
+    IAgenticaRpcService<"chatgpt">,
+    IAgenticaRpcListener
+  > = new WebSocketServer();
+  await server.open(port, async (acceptor) => {
+    const agent: Agentica<"chatgpt"> = new Agentica({
+      model: "chatgpt",
+      vendor: {
+        model: "gpt-4o-mini",
+        api: new OpenAI({
+          apiKey: TestGlobal.chatgptApiKey,
+        }),
+      },
+      controllers: [],
+    });
+    await acceptor.accept(
+      new AgenticaRpcService({
+        agent,
+        listener: acceptor.getDriver(),
+      }),
+    );
+  });
+
+  const events: IAgenticaEventJson[] = [];
+  const connector: WebSocketConnector<
+    null,
+    IAgenticaRpcListener,
+    IAgenticaRpcService<"chatgpt">
+  > = new WebSocketConnector(null, {
+    describe: async (evt) => {
+      events.push(evt);
+    },
+    text: async (evt) => {
+      events.push(evt);
+    },
+    initialize: async (evt) => {
+      events.push(evt);
+    },
+  });
+  await connector.connect(`ws://localhost:${port}`);
+
+  const driver: Driver<IAgenticaRpcService<"chatgpt">> = connector.getDriver();
+  await driver.conversate("What can you do?");
+  await connector.close();
+  await server.close();
+
+  TestValidator.equals("events")([
+    {
+      type: "text",
+      role: "user",
+    },
+    {
+      type: "initialize",
+    },
+    {
+      type: "text",
+      role: "assistant",
+    },
+  ])(events);
+}


### PR DESCRIPTION
This pull request includes several changes to the RPC service and its associated tests. The most important changes involve updating the type definitions, adding a new test for WebSocket calls, and renaming and modifying an existing test.

### Type Definition Updates:
* Updated the return type of the `call` method in the `IAgenticaRpcListener` interface to include `void` as a possible return type. (`packages/rpc/src/IAgenticaRpcListener.ts`, [packages/rpc/src/IAgenticaRpcListener.tsL108-R108](diffhunk://#diff-a7449615bfcbf476b208fba4f3ce6cf07efc4e9021702d06c8c920a71c6ea599L108-R108))
* Modified the `call` method in the `AgenticaRpcService` to handle the updated return type of the `call` method in the `IAgenticaRpcListener` interface. (`packages/rpc/src/AgenticaRpcService.ts`, [packages/rpc/src/AgenticaRpcService.tsL81-R81](diffhunk://#diff-ff117542d38be6a7963841ec4b486914ee24ac26cbc15c123525060a9ea084edL81-R81))

### Test Additions:
* Added a new test `test_rpc_websocket_call` to validate the WebSocket call functionality, including the setup of the `Agentica` instance and the WebSocket server. (`test/src/features/rpc/test_rpc_websocket_call.ts`, [test/src/features/rpc/test_rpc_websocket_call.tsR1-R113](diffhunk://#diff-76d9a40cf186198718fadc82443296eef1dfefe6d222483ea6aeb559e883f018R1-R113))

### Test Modifications:
* Renamed the test `test_base_websocket` to `test_rpc_websocket_initialize` and updated the import paths accordingly. (`test/src/features/rpc/test_rpc_websocket_initialize.ts`, [[1]](diffhunk://#diff-f8908b541db756f437b57eb09f7a4caac77443a7b22961294bbf9bd79a5a86f2L17-R19) [[2]](diffhunk://#diff-f8908b541db756f437b57eb09f7a4caac77443a7b22961294bbf9bd79a5a86f2L70)