### PR TITLE
feat(web): add additional link about developer section on footer

### DIFF
--- a/website/app/_components/layout/Footer.tsx
+++ b/website/app/_components/layout/Footer.tsx
@@ -23,6 +23,7 @@ const FOOTER_CONTENTS = [
       { label: "Autoview", href: "https://wrtnlabs.io/autoview/" },
       { label: "Github", href: "https://github.com/wrtnlabs" },
       { label: "Docs", href: "https://wrtnlabs.io/agentica/docs/" },
+      { label: "Discord", href: "https://discord.gg/aMhRmzkqCx" },
     ],
   },
 ];


### PR DESCRIPTION
This pull request includes a small change to the `website/app/_components/layout/Footer.tsx` file. The change adds a link to the Discord server in the footer.

* [`website/app/_components/layout/Footer.tsx`](diffhunk://#diff-fbe7438c69ee8a131445c3bfa6db33e554ff31312166e75957881a720bca4427R26): Added a new footer link to the Discord server.