### PR TITLE
fix(core): not to emit select history from `MicroAgentica`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentica/station",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "private": true,
   "packageManager": "pnpm@10.6.4",
   "description": "Agentic AI library specialized in LLM Function Calling",

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -27,7 +27,7 @@ import { AgenticaConstant } from "../constants/AgenticaConstant";
 import { AgenticaDefaultPrompt } from "../constants/AgenticaDefaultPrompt";
 import { AgenticaSystemPrompt } from "../constants/AgenticaSystemPrompt";
 import { isAgenticaContext } from "../context/internal/isAgenticaContext";
-import { createCallEvent, createCancelEvent, createExecuteEvent, createTextEvent, createValidateEvent } from "../factory/events";
+import { createCallEvent, createExecuteEvent, createTextEvent, createValidateEvent } from "../factory/events";
 import { createCancelHistory, createExecuteHistory, createTextHistory, decodeHistory } from "../factory/histories";
 import { createOperationSelection } from "../factory/operations";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
@@ -116,7 +116,7 @@ export async function call<Model extends ILlmSchema.Model>(
         }
         closures.push(
           async (): Promise<
-            [AgenticaExecuteHistory<Model>, AgenticaCancelHistory<Model>]
+            Array<AgenticaExecuteHistory<Model> | AgenticaCancelHistory<Model>>
           > => {
             const call: AgenticaCallEvent<Model> = createCallEvent({
               id: tc.id,
@@ -147,31 +147,24 @@ export async function call<Model extends ILlmSchema.Model>(
             ).catch(() => {});
 
             if (isAgenticaContext(ctx)) {
-              await cancelFunction(ctx, {
+              cancelFunction(ctx, {
                 name: call.operation.name,
                 reason: "completed",
               });
-              ctx.dispatch(
-                createCancelEvent({
-                  selection: createOperationSelection({
-                    operation: call.operation,
-                    reason: "complete",
-                  }),
+              return [
+                execute,
+                createCancelHistory({
+                  id: call.id,
+                  selections: [
+                    createOperationSelection({
+                      operation: call.operation,
+                      reason: "complete",
+                    }),
+                  ],
                 }),
-              ).catch(() => {});
+              ];
             }
-            return [
-              execute,
-              createCancelHistory({
-                id: call.id,
-                selections: [
-                  createOperationSelection({
-                    operation: call.operation,
-                    reason: "complete",
-                  }),
-                ],
-              }),
-            ] as const;
+            return [execute];
           },
         );
       }

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -34,6 +34,7 @@ interface IFailure {
 }
 
 export async function cancel<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>): Promise<AgenticaCancelHistory<Model>[]> {
+  console.error("orchestrate.cancel");
   if (ctx.operations.divided === undefined) {
     return step(ctx, ctx.operations.array, 0);
   }
@@ -85,7 +86,7 @@ export async function cancel<Model extends ILlmSchema.Model>(ctx: AgenticaContex
   for (const e of events) {
     if (e.type === "select") {
       collection.selections.push(e.selection);
-      await cancelFunction(ctx, {
+      cancelFunction(ctx, {
         name: e.selection.operation.name,
         reason: e.selection.reason,
       });
@@ -231,7 +232,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
         });
 
         for (const reference of input.functions) {
-          const operation = await cancelFunction(ctx, reference);
+          const operation = cancelFunction(ctx, reference);
           if (operation !== null) {
             collection.selections.push(operation);
           }

--- a/packages/core/src/orchestrate/execute.ts
+++ b/packages/core/src/orchestrate/execute.ts
@@ -9,7 +9,6 @@ import { call } from "./call";
 import { cancel } from "./cancel";
 import { describe } from "./describe";
 import { initialize } from "./initialize";
-import { cancelFunction } from "./internal/cancelFunction";
 import { select } from "./select";
 
 export function execute<Model extends ILlmSchema.Model>(executor: Partial<IAgenticaExecutor<Model>> | null) {
@@ -64,12 +63,6 @@ export function execute<Model extends ILlmSchema.Model>(executor: Partial<IAgent
       const executes: AgenticaExecuteHistory<Model>[] = prompts.filter(
         prompt => prompt.type === "execute",
       );
-      for (const e of executes) {
-        await cancelFunction(ctx, {
-          reason: "completed",
-          name: e.operation.name,
-        });
-      }
       histories.push(
         ...(await (
           executor?.describe ?? describe

--- a/packages/core/src/orchestrate/internal/cancelFunction.ts
+++ b/packages/core/src/orchestrate/internal/cancelFunction.ts
@@ -10,10 +10,10 @@ import { createOperationSelection } from "../../factory/operations";
 /**
  * @internal
  */
-export async function cancelFunction<Model extends ILlmSchema.Model>(
+export function cancelFunction<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model>,
   reference: __IChatFunctionReference,
-): Promise<AgenticaOperationSelection<Model> | null> {
+): AgenticaOperationSelection<Model> | null {
   const index: number = ctx.stack.findIndex(
     item => item.operation.name === reference.name,
   );
@@ -23,13 +23,13 @@ export async function cancelFunction<Model extends ILlmSchema.Model>(
 
   const item: AgenticaOperationSelection<Model> = ctx.stack[index]!;
   ctx.stack.splice(index, 1);
-  await ctx.dispatch(
+  ctx.dispatch(
     createCancelEvent({
       selection: createOperationSelection({
         operation: item.operation,
         reason: reference.reason,
       }),
     }),
-  );
+  ).catch(() => {});
   return item;
 }

--- a/test/src/features/test_micro_agentica.ts
+++ b/test/src/features/test_micro_agentica.ts
@@ -50,6 +50,7 @@ export async function test_micro_agentica(): Promise<void | false> {
     strategy. Let's visit typia website https://typia.io, and enjoy 
     its super-fast performance.
   `);
+  typia.assert<MicroAgenticaHistory.Type[]>(agent.getHistories().map(h => h.type));
   if (predicate(agent.getHistories()) === false) {
     await agent.conversate("Do it.");
     const result: boolean = predicate(agent.getHistories());


### PR DESCRIPTION
This pull request includes several changes to the `packages/core/src/orchestrate` module and related files to simplify the codebase and improve functionality. The most important changes involve removing unnecessary asynchronous calls, updating function signatures, and adding error logging.

### Codebase simplification:

* [`packages/core/src/orchestrate/call.ts`](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL30-R30): Removed the `createCancelEvent` import and updated the return type of closures to use an array instead of a tuple. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL30-R30) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL119-R119)
* [`packages/core/src/orchestrate/call.ts`](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL150-L162): Removed redundant asynchronous calls to `cancelFunction` and adjusted the return statements accordingly. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL150-L162) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL174-R167)
* [`packages/core/src/orchestrate/cancel.ts`](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148R37): Added an error log statement in the `cancel` function and removed unnecessary `await` in calls to `cancelFunction`. [[1]](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148R37) [[2]](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148L88-R89) [[3]](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148L234-R235)
* [`packages/core/src/orchestrate/execute.ts`](diffhunk://#diff-a115829420f03584dea6fbde1fec1dc0dfa79362c86330246b93f8dd3e1b660eL12): Removed the `cancelFunction` import and its redundant usage in the `execute` function. [[1]](diffhunk://#diff-a115829420f03584dea6fbde1fec1dc0dfa79362c86330246b93f8dd3e1b660eL12) [[2]](diffhunk://#diff-a115829420f03584dea6fbde1fec1dc0dfa79362c86330246b93f8dd3e1b660eL67-L72)
* [`packages/core/src/orchestrate/internal/cancelFunction.ts`](diffhunk://#diff-9831fd53eaf363349fa841566c7951ac48da6e796ef38cc2851bd644359c063fL13-R16): Updated the `cancelFunction` to be synchronous and removed the `await` keyword from its internal dispatch call. [[1]](diffhunk://#diff-9831fd53eaf363349fa841566c7951ac48da6e796ef38cc2851bd644359c063fL13-R16) [[2]](diffhunk://#diff-9831fd53eaf363349fa841566c7951ac48da6e796ef38cc2851bd644359c063fL26-R33)

### Other changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `0.16.4` to `0.16.5`.
* [`test/src/features/test_micro_agentica.ts`](diffhunk://#diff-94c33e3ee0df020210ddd00df08faf149da6234953f9bd5978d8ec6846748e44R53): Added a type assertion using `typia.assert` for `MicroAgenticaHistory.Type[]`.