### PR TITLE
Fix(core): bug of streaming (openrouter only)

### DIFF
--- a/packages/core/src/Agentica.ts
+++ b/packages/core/src/Agentica.ts
@@ -131,7 +131,7 @@ export class Agentica<Model extends ILlmSchema.Model> {
       role: "user",
       text: content,
     });
-    await this.dispatch(
+    this.dispatch(
       createTextEvent({
         role: "user",
         stream: StreamUtil.to(content),
@@ -139,7 +139,7 @@ export class Agentica<Model extends ILlmSchema.Model> {
         get: () => content,
         join: async () => Promise.resolve(content),
       }),
-    );
+    ).catch(() => {});
 
     const newbie: AgenticaHistory<Model>[] = await this.executor_(
       this.getContext({

--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -112,7 +112,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
       role: "user",
       text: content,
     });
-    await this.dispatch(
+    this.dispatch(
       createTextEvent({
         role: "user",
         stream: StreamUtil.to(content),
@@ -120,7 +120,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
         get: () => content,
         join: async () => Promise.resolve(content),
       }),
-    );
+    ).catch(() => {});
 
     const ctx: MicroAgenticaContext<Model> = this.getContext({
       prompt: talk,

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -171,8 +171,8 @@ export async function call<Model extends ILlmSchema.Model>(
     }
     if (
       choice.message.role === "assistant"
-      && choice.message.content !== null
-      && choice.message.content.length > 0
+      && choice.message.content != null
+      && choice.message.content.length !== 0
     ) {
       closures.push(async () => {
         const value: AgenticaTextHistory = createTextHistory({

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -34,7 +34,6 @@ interface IFailure {
 }
 
 export async function cancel<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>): Promise<AgenticaCancelHistory<Model>[]> {
-  console.error("orchestrate.cancel");
   if (ctx.operations.divided === undefined) {
     return step(ctx, ctx.operations.array, 0);
   }

--- a/packages/core/src/orchestrate/initialize.ts
+++ b/packages/core/src/orchestrate/initialize.ts
@@ -88,7 +88,7 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
           continue;
         }
 
-        if (choice.delta.content == null) {
+        if (choice.delta.content == null || choice.delta.content.length === 0) {
           continue;
         }
 
@@ -142,6 +142,7 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
     if (
       choice.message.role === "assistant"
       && choice.message.content != null
+      && choice.message.content.length !== 0
     ) {
       prompts.push(
         createTextHistory({

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -258,6 +258,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
     if (
       choice.message.role === "assistant"
       && choice.message.content != null
+      && choice.message.content.length !== 0
     ) {
       const text: AgenticaTextHistory = createTextHistory({
         role: "assistant",

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -266,7 +266,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
       });
       prompts.push(text);
 
-      await ctx.dispatch(
+      ctx.dispatch(
         createTextEvent({
           role: "assistant",
           stream: StreamUtil.to(text.text),
@@ -274,7 +274,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
           done: () => true,
           get: () => text.text,
         }),
-      );
+      ).catch(() => {});
     }
   }
 

--- a/test/src/TestGlobal.ts
+++ b/test/src/TestGlobal.ts
@@ -49,4 +49,5 @@ interface IEnvironments {
   CHATGPT_API_KEY?: string;
   CHATGPT_BASE_URL?: string;
   CHATGPT_OPTIONS?: string;
+  OPENROUTER_API_KEY?: string;
 }

--- a/test/src/features/bugs/test_bug_openrouter_streaming.ts
+++ b/test/src/features/bugs/test_bug_openrouter_streaming.ts
@@ -1,0 +1,64 @@
+import { Agentica } from "@agentica/core";
+import OpenAI from "openai";
+import typia from "typia";
+
+import { BbsArticleService } from "../../internal/BbsArticleService";
+import { TestGlobal } from "../../TestGlobal";
+
+export async function test_bug_openrouter_streaming(): Promise<void | false> {
+  if (TestGlobal.env.OPENROUTER_API_KEY === undefined) {
+    return false;
+  }
+
+  const agent: Agentica<"chatgpt"> = new Agentica({
+    model: "chatgpt",
+    vendor: {
+      api: new OpenAI({
+        apiKey: TestGlobal.env.OPENROUTER_API_KEY,
+        baseURL: "https://openrouter.ai/api/v1",
+      }),
+      model: "openai/gpt-4o-mini",
+    },
+    controllers: [
+      {
+        protocol: "class",
+        name: "bbs",
+        application: typia.llm.application<BbsArticleService, "chatgpt">(),
+        execute: new BbsArticleService(),
+      },
+    ],
+  });
+  agent.on("text", async (event) => {
+    if (event.role === "assistant") {
+      const reader = event.stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        console.log(value);
+      }
+    }
+  });
+
+  await agent.conversate(`
+    I will create a new article.
+
+    Title is "Introduce typia, superfast runtime validator", and thumbnail URL is https://typia.io/logo.png
+
+    Content body is below.
+
+    "typia" is a transformer library supporting below features:
+
+    - Super-fast runtime validators
+    - Enhanced JSON schema and serde functions
+    - LLM function calling schema and structured output
+    - Protocol Buffer encoder and decoder
+    - Random data generator
+
+    For reference, "typia"'s runtime validator 20,000x faster than 
+    "class-validator" by utilizing the AoT (Ahead of Time) compilation 
+    strategy. Let's visit typia website https://typia.io, and enjoy 
+    its super-fast performance.
+  `);
+}


### PR DESCRIPTION
In the OpenAI SDK, if no text message comes from the AI agent, it must become `null` value.

However, `openrouter` ignores the rule, and just assign the zero length string value.

This PR avoids such domain bug of openrouter by checking string length.

-----------------

This pull request introduces a new feature for OpenRouter streaming and updates the environment configuration to support it. The key changes include adding a new API key to the environment interface and implementing a test function for OpenRouter streaming.

### Environment Configuration Updates:
* [`test/src/TestGlobal.ts`](diffhunk://#diff-35da97a7f8d40740805b0a37c632c25ba24082e30adfead3ef6045e06f7eb086R52): Added `OPENROUTER_API_KEY` to the `IEnvironments` interface to support the new OpenRouter streaming feature.

### New Feature Implementation:
* [`test/src/features/bugs/test_bug_openrouter_streaming.ts`](diffhunk://#diff-5d910366dd7bf4fbde8001275154c3efb2c1821784f53b03b43ab6d61d52a53fR1-R64): Implemented the `test_bug_openrouter_streaming` function, which sets up an `Agentica` instance using the OpenRouter API and streams text from the assistant role. The function includes a sample conversation to create a new article using the `BbsArticleService`.