### PR TITLE
feat(core): Change the difficult stream to a more familiar generator.

### DIFF
--- a/packages/core/src/Agentica.ts
+++ b/packages/core/src/Agentica.ts
@@ -22,7 +22,7 @@ import { execute } from "./orchestrate/execute";
 import { AgenticaHistoryTransformer } from "./transformers/AgenticaHistoryTransformer";
 import { __map_take } from "./utils/__map_take";
 import { ChatGptCompletionMessageUtil } from "./utils/ChatGptCompletionMessageUtil";
-import { StreamUtil } from "./utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil, toAsyncGenerator } from "./utils/StreamUtil";
 
 /**
  * Agentica AI chatbot agent.
@@ -134,7 +134,7 @@ export class Agentica<Model extends ILlmSchema.Model> {
     this.dispatch(
       createTextEvent({
         role: "user",
-        stream: StreamUtil.to(content),
+        stream: toAsyncGenerator(content),
         done: () => true,
         get: () => content,
         join: async () => Promise.resolve(content),
@@ -282,7 +282,7 @@ export class Agentica<Model extends ILlmSchema.Model> {
         await dispatch({
           type: "response",
           source,
-          stream: streamForStream,
+          stream: streamDefaultReaderToAsyncGenerator(streamForStream.getReader()),
           body: event.body,
           options: event.options,
           join: async () => {

--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -21,7 +21,7 @@ import { call, describe } from "./orchestrate";
 import { AgenticaHistoryTransformer } from "./transformers/AgenticaHistoryTransformer";
 import { __map_take } from "./utils/__map_take";
 import { ChatGptCompletionMessageUtil } from "./utils/ChatGptCompletionMessageUtil";
-import { StreamUtil } from "./utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil, toAsyncGenerator } from "./utils/StreamUtil";
 
 /**
  * Micro AI chatbot.
@@ -115,7 +115,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
     this.dispatch(
       createTextEvent({
         role: "user",
-        stream: StreamUtil.to(content),
+        stream: toAsyncGenerator(content),
         done: () => true,
         get: () => content,
         join: async () => Promise.resolve(content),
@@ -252,7 +252,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
         await dispatch({
           type: "response",
           source,
-          stream: streamForStream,
+          stream: streamDefaultReaderToAsyncGenerator(streamForStream.getReader()),
           body: event.body,
           options: event.options,
           join: async () => {

--- a/packages/core/src/events/AgenticaDescribeEvent.ts
+++ b/packages/core/src/events/AgenticaDescribeEvent.ts
@@ -10,7 +10,7 @@ export interface AgenticaDescribeEvent<
   Model extends ILlmSchema.Model,
 > extends AgenticaEventBase<"describe"> {
   executes: AgenticaExecuteHistory<Model>[];
-  stream: ReadableStream<string>;
+  stream: AsyncGenerator<string, undefined, undefined>;
 
   join: () => Promise<string>;
   toJSON: () => IAgenticaEventJson.IDescribe;

--- a/packages/core/src/events/AgenticaResponseEvent.ts
+++ b/packages/core/src/events/AgenticaResponseEvent.ts
@@ -17,7 +17,7 @@ export interface AgenticaResponseEvent extends AgenticaEventBase<"response"> {
   /**
    * The text content stream.
    */
-  stream: ReadableStream<OpenAI.ChatCompletionChunk>;
+  stream: AsyncGenerator<OpenAI.ChatCompletionChunk, undefined, undefined>;
 
   /**
    * Options for the request.

--- a/packages/core/src/events/AgenticaTextEvent.ts
+++ b/packages/core/src/events/AgenticaTextEvent.ts
@@ -7,7 +7,7 @@ export interface AgenticaTextEvent<
   Role extends "assistant" | "user" = "assistant" | "user",
 > extends AgenticaEventBase<"text"> {
   role: Role;
-  stream: ReadableStream<string>;
+  stream: AsyncGenerator<string, undefined, undefined>;
   join: () => Promise<string>;
   toJSON: () => IAgenticaEventJson.IText;
   toHistory: () => AgenticaTextHistory;

--- a/packages/core/src/factory/events.ts
+++ b/packages/core/src/factory/events.ts
@@ -136,7 +136,7 @@ export function createExecuteEvent<Model extends ILlmSchema.Model>(props: {
 ----------------------------------------------------------- */
 export function createTextEvent<Role extends "user" | "assistant">(props: {
   role: Role;
-  stream: ReadableStream<string>;
+  stream: AsyncGenerator<string, undefined, undefined>;
   done: () => boolean;
   get: () => string;
   join: () => Promise<string>;
@@ -167,7 +167,7 @@ export function createTextEvent<Role extends "user" | "assistant">(props: {
 
 export function createDescribeEvent<Model extends ILlmSchema.Model>(props: {
   executes: AgenticaExecuteHistory<Model>[];
-  stream: ReadableStream<string>;
+  stream: AsyncGenerator<string, undefined, undefined>;
   done: () => boolean;
   get: () => string;
   join: () => Promise<string>;
@@ -216,7 +216,7 @@ export function createResponseEvent(props: {
   source: AgenticaEventSource;
   body: OpenAI.ChatCompletionCreateParamsStreaming;
   options?: OpenAI.RequestOptions | undefined;
-  stream: ReadableStream<OpenAI.ChatCompletionChunk>;
+  stream: AsyncGenerator<OpenAI.ChatCompletionChunk, undefined, undefined>;
   join: () => Promise<OpenAI.ChatCompletion>;
 }): AgenticaResponseEvent {
   return {

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -31,7 +31,7 @@ import { createCallEvent, createExecuteEvent, createTextEvent, createValidateEve
 import { createCancelHistory, createExecuteHistory, createTextHistory, decodeHistory } from "../factory/histories";
 import { createOperationSelection } from "../factory/operations";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
-import { StreamUtil } from "../utils/StreamUtil";
+import { StreamUtil, toAsyncGenerator } from "../utils/StreamUtil";
 
 import { cancelFunction } from "./internal/cancelFunction";
 
@@ -184,7 +184,7 @@ export async function call<Model extends ILlmSchema.Model>(
             role: "assistant",
             get: () => value.text,
             done: () => true,
-            stream: StreamUtil.to(value.text),
+            stream: toAsyncGenerator(value.text),
             join: async () => Promise.resolve(value.text),
           }),
         ).catch(() => {});

--- a/packages/core/src/orchestrate/describe.ts
+++ b/packages/core/src/orchestrate/describe.ts
@@ -12,7 +12,7 @@ import { createDescribeEvent } from "../factory/events";
 import { createDescribeHistory, decodeHistory } from "../factory/histories";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
 import { MPSC } from "../utils/MPSC";
-import { StreamUtil } from "../utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "../utils/StreamUtil";
 
 export async function describe<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model> | MicroAgenticaContext<Model>,
@@ -85,7 +85,7 @@ export async function describe<Model extends ILlmSchema.Model>(
         ctx.dispatch(
           createDescribeEvent({
             executes: histories,
-            stream: mpsc.consumer,
+            stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
             done: () => mpsc.done(),
             get: () => describeContext[choice.index]?.content ?? "",
             join: async () => {

--- a/packages/core/src/orchestrate/initialize.ts
+++ b/packages/core/src/orchestrate/initialize.ts
@@ -13,7 +13,7 @@ import { createTextEvent } from "../factory/events";
 import { createTextHistory, decodeHistory } from "../factory/histories";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
 import { MPSC } from "../utils/MPSC";
-import { StreamUtil } from "../utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "../utils/StreamUtil";
 
 const FUNCTION: ILlmFunction<"chatgpt"> = typia.llm.application<
   __IChatInitialApplication,
@@ -109,7 +109,7 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
         ctx.dispatch(
           createTextEvent({
             role: "assistant",
-            stream: mpsc.consumer,
+            stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
             done: () => mpsc.done(),
             get: () => textContext[choice.index]!.content,
             join: async () => {

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -22,7 +22,7 @@ import { createTextEvent } from "../factory/events";
 import { createSelectHistory, createTextHistory, decodeHistory } from "../factory/histories";
 import { createOperationSelection } from "../factory/operations";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
-import { StreamUtil } from "../utils/StreamUtil";
+import { StreamUtil, toAsyncGenerator } from "../utils/StreamUtil";
 
 import { selectFunction } from "./internal/selectFunction";
 
@@ -269,7 +269,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
       ctx.dispatch(
         createTextEvent({
           role: "assistant",
-          stream: StreamUtil.to(text.text),
+          stream: toAsyncGenerator(text.text),
           join: async () => Promise.resolve(text.text),
           done: () => true,
           get: () => text.text,

--- a/packages/core/src/transformers/AgenticaEventTransformer.ts
+++ b/packages/core/src/transformers/AgenticaEventTransformer.ts
@@ -14,7 +14,7 @@ import type { IAgenticaEventJson } from "../json/IAgenticaEventJson";
 
 import { createCallEvent, createCancelEvent, createDescribeEvent, createExecuteEvent, createInitializeEvent, createRequestEvent, createSelectEvent, createTextEvent } from "../factory/events";
 import { createOperationSelection } from "../factory/operations";
-import { StreamUtil } from "../utils/StreamUtil";
+import { toAsyncGenerator } from "../utils/StreamUtil";
 
 function findOperation<Model extends ILlmSchema.Model>(props: {
   operations: Map<string, Map<string, AgenticaOperation<Model>>>;
@@ -124,7 +124,7 @@ function transformDescribe<Model extends ILlmSchema.Model>(props: {
         event: next,
       }),
     ),
-    stream: StreamUtil.to(props.event.text),
+    stream: toAsyncGenerator(props.event.text),
     done: () => true,
     get: () => props.event.text,
     join: async () => props.event.text,
@@ -176,7 +176,7 @@ function transformText(props: {
 }): AgenticaTextEvent {
   return createTextEvent({
     role: props.event.role,
-    stream: StreamUtil.to(props.event.text),
+    stream: toAsyncGenerator(props.event.text),
     done: () => true,
     get: () => props.event.text,
     join: async () => props.event.text,

--- a/test/src/features/test_base_streaming.ts
+++ b/test/src/features/test_base_streaming.ts
@@ -46,13 +46,7 @@ export async function test_base_streaming(): Promise<void | false> {
   agent.on("response", async (event: AgenticaResponseEvent) => {
     responseEventFired = true;
     // Test the stream
-    const reader = event.stream.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      // Collect content from stream chunks
+    for await (const value of event.stream) {
       if (value.choices !== undefined && value.choices[0]?.delta?.content !== undefined) {
         streamContentPieces.push(value.choices[0].delta.content as string);
       }

--- a/test/src/features/test_base_streaming_describe.ts
+++ b/test/src/features/test_base_streaming_describe.ts
@@ -92,16 +92,7 @@ export async function test_base_streaming_describe(): Promise<void | false> {
     describeStreamProcessed = true;
     describeJoinResult = await event.join();
 
-    const reader = event.stream.getReader();
-    while (true) {
-      const { done, value } = await reader.read().catch((e) => {
-        console.error(e);
-        return { done: true, value: undefined };
-      });
-      if (done) {
-        break;
-      }
-
+    for await (const value of event.stream) {
       // Extract text content from stream chunks
       try {
         if (typeof value === "string") {

--- a/test/src/features/unit/stream/test_stream_from.ts
+++ b/test/src/features/unit/stream/test_stream_from.ts
@@ -1,7 +1,7 @@
-import { utils } from "@agentica/core";
+import { StreamUtil } from "@agentica/core/src/utils/StreamUtil";
 
-export async function test_stream_to(): Promise<void | false> {
-  const stream = utils.StreamUtil.to("Hello, world!");
+export async function test_stream_from(): Promise<void | false> {
+  const stream = StreamUtil.from("Hello, world!");
   const reader = stream.getReader();
   const { done, value } = await reader.read();
 

--- a/test/src/features/unit/stream/test_stream_from.ts
+++ b/test/src/features/unit/stream/test_stream_from.ts
@@ -1,7 +1,7 @@
-import { StreamUtil } from "@agentica/core/src/utils/StreamUtil";
+import { utils } from "@agentica/core";
 
 export async function test_stream_from(): Promise<void | false> {
-  const stream = StreamUtil.from("Hello, world!");
+  const stream = utils.StreamUtil.from("Hello, world!");
   const reader = stream.getReader();
   const { done, value } = await reader.read();
 


### PR DESCRIPTION
This pull request includes several changes to the `Agentica` and `MicroAgentica` classes, focusing on updating the stream handling mechanism from `ReadableStream` to `AsyncGenerator` across various files. The most important changes are grouped by theme and listed below:

### Stream Handling Updates:

* Updated imports and usage of stream utilities to use `toAsyncGenerator` and `streamDefaultReaderToAsyncGenerator` in `Agentica` and `MicroAgentica` classes (`packages/core/src/Agentica.ts`, `packages/core/src/MicroAgentica.ts`). [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L25-R25) [[2]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L137-R137) [[3]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L285-R285) [[4]](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L24-R24) [[5]](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L118-R118) [[6]](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L255-R255)
* Changed the stream type from `ReadableStream` to `AsyncGenerator` in event interfaces (`AgenticaDescribeEvent`, `AgenticaResponseEvent`, `AgenticaTextEvent`) (`packages/core/src/events/AgenticaDescribeEvent.ts`, `packages/core/src/events/AgenticaResponseEvent.ts`, `packages/core/src/events/AgenticaTextEvent.ts`). [[1]](diffhunk://#diff-9aa09ec16f553628a818a254beba1a456724e5729da7aa0af0a10da4d0b76d19L13-R13) [[2]](diffhunk://#diff-c80ac4f003c08c7601ee252862f4a318ac646180d61b19854dce3b21a81f457fL20-R20) [[3]](diffhunk://#diff-9b846a8f253d247013115bda13482bf5002238d3e88577dcef12aa7eb3df696aL10-R10)
* Modified event creation functions to use `AsyncGenerator` streams (`createExecuteEvent`, `createTextEvent`, `createDescribeEvent`, `createResponseEvent`) (`packages/core/src/factory/events.ts`). [[1]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78L139-R139) [[2]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78L170-R170) [[3]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78L219-R219)
* Updated stream handling in orchestration functions (`call`, `describe`, `initialize`, `select`) to use `toAsyncGenerator` and `streamDefaultReaderToAsyncGenerator` (`packages/core/src/orchestrate/call.ts`, `packages/core/src/orchestrate/describe.ts`, `packages/core/src/orchestrate/initialize.ts`, `packages/core/src/orchestrate/select.ts`). [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL34-R34) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL187-R187) [[3]](diffhunk://#diff-7e388d3e009ebecbe7b78b75a4f9f6bd997ec41519081e84577591e431ca463fL15-R15) [[4]](diffhunk://#diff-7e388d3e009ebecbe7b78b75a4f9f6bd997ec41519081e84577591e431ca463fL88-R88) [[5]](diffhunk://#diff-cd69613b95454c4f1c769717b34a1413c863c2c73dd8594d4db6f69afb21c4c0L16-R16) [[6]](diffhunk://#diff-cd69613b95454c4f1c769717b34a1413c863c2c73dd8594d4db6f69afb21c4c0L112-R112) [[7]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL25-R25) [[8]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL272-R272)
* Adjusted stream utilities to include `toAsyncGenerator` and `streamDefaultReaderToAsyncGenerator` functions, and renamed `to` to `from` (`packages/core/src/utils/StreamUtil.ts`). [[1]](diffhunk://#diff-51490b164f1a78460caac8bada1dd2d99885b0e448e062996d24c4e17458aea7L22-R25) [[2]](diffhunk://#diff-51490b164f1a78460caac8bada1dd2d99885b0e448e062996d24c4e17458aea7L41-R37) [[3]](diffhunk://#diff-51490b164f1a78460caac8bada1dd2d99885b0e448e062996d24c4e17458aea7R48-R61) [[4]](diffhunk://#diff-51490b164f1a78460caac8bada1dd2d99885b0e448e062996d24c4e17458aea7L71-R81)

### Test Updates:

* Updated test cases to reflect the changes in stream handling from `ReadableStream` to `AsyncGenerator` (`test/src/features/test_base_streaming.ts`, `test/src/features/test_base_streaming_describe.ts`, `test/src/features/unit/stream/test_stream_from.ts`). [[1]](diffhunk://#diff-6174faa7a55af8f5e9cb35c905799351db7eb9cccb6b7953e8066fad2e24e9e4L49-R49) [[2]](diffhunk://#diff-57e9a5bc19972b4accb7870ff1309db30f8338bbde17b8e0cc14ee1ee349f5d1L95-R95) [[3]](diffhunk://#diff-8448e216fbd6a61181001a73868d13cc0c33f98546894b3e183239d0a2a0d168L1-R4)