### PR TITLE
docs(website): some videos

### DIFF
--- a/website/content/docs/core/controller/swagger.mdx
+++ b/website/content/docs/core/controller/swagger.mdx
@@ -7,6 +7,16 @@ import RemoteSource from "../../../../components/RemoteSource";
 
 import OpenApiDiagramSnippet from "../../../snippets/OpenApiDiagramSnippet.mdx";
 
+<br/>
+<iframe 
+  src="https://www.youtube.com/embed/AGZ9hlaln7E" 
+  title="Plug in OpenAPI, Get an AI Agent" 
+  width="100%" 
+  height="500" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen 
+/>
+
 ## Swagger/OpenAPI
 ```typescript filename="src/main.ts" showLineNumbers {16-31}
 import {

--- a/website/content/docs/core/controller/typescript.mdx
+++ b/website/content/docs/core/controller/typescript.mdx
@@ -12,6 +12,16 @@ import DocumentationStrategyDtoDescriptionSnippet from "../../../snippets/Docume
 import DocumentationStrategyPropertyDescriptionSnippet from "../../../snippets/DocumentationStrategyPropertyDescriptionSnippet.mdx";
 import DocumentationStrategyNamespaceSnippet from "../../../snippets/DocumentationStrategyNamespaceSnippet.mdx";
 
+<br/>
+<iframe 
+  src="https://www.youtube.com/embed/czLC-N9ZRnY" 
+  title="Turn Your TypeScript Class into an AI Agent" 
+  width="100%" 
+  height="500" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen 
+/>
+
 ## TypeScript Class
 <Tabs items={[
   <code>src/main.ts</code>,

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -57,9 +57,9 @@ import AgenticaExampleActualSnippet from "../snippets/AgenticaExampleActualSnipp
 
 The simplest **Agentic AI** library, specialized in **LLM Function Calling**.
 
-Don't compose complicate agent graph or workflow, but just deliver **Swagger/OpenAPI** documents or **TypeScript class** types linearly to the `agentica`. Then `agentica` will do everything with the function calling.
+Don't make complicate agent graph or workflow, but just list up **Swagger/OpenAPI/MCP** documents or **TypeScript class** types to the `@agentica`. Then `@agentica` will do everything with the function calling.
 
-Look at the below demonstration, and feel how `agentica` is easy and powerful. You can let users to search and purchase products only with conversation texts. The backend API and TypeScript class functions would be adequately called in the AI chatbot with LLM function calling.
+Look at the below demonstration, and feel how `@agentica` is easy and powerful. You can let users to search and purchase products only with conversation texts. The backend API and TypeScript class functions would be adequately called in the AI chatbot with LLM function calling.
 
 <Tabs items={["Pseudo Code", "Actual Code"]}>
   <Tabs.Tab>

--- a/website/content/docs/plugins/openai-vector-store.mdx
+++ b/website/content/docs/plugins/openai-vector-store.mdx
@@ -2,4 +2,12 @@
 title: Agentica > Guide Documents > Plugin Modules > OpenAI Vector Store
 ---
 
-@todo Kakasoo
+<br/>
+<iframe 
+  src="https://www.youtube.com/embed/zEtMXzHwzX0" 
+  title="From PDF to Smart AI — RAG Made Easy" 
+  width="100%" 
+  height="500" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen 
+/>


### PR DESCRIPTION
This pull request includes several changes to the documentation files to embed YouTube videos and update the description of `@agentica`. The most important changes include the addition of iframes for YouTube videos and updates to the description of `@agentica`.

### Embedding YouTube Videos:

* [`website/content/docs/core/controller/swagger.mdx`](diffhunk://#diff-4d2606759cd72db8c3b0b8ff639c666cd86e68de35cc425656377a75de11ec63R10-R19): Added an iframe to embed a YouTube video titled "Plug in OpenAPI, Get an AI Agent".
* [`website/content/docs/core/controller/typescript.mdx`](diffhunk://#diff-4ba45f22ef80d3b4b8cf4454a87428e7af7546a93e1717a2118828db77382433R15-R24): Added an iframe to embed a YouTube video titled "Turn Your TypeScript Class into an AI Agent".
* [`website/content/docs/plugins/openai-vector-store.mdx`](diffhunk://#diff-a81547e3663d643d630cbe5d6f837cd9ea86960cb6670897e2a9953a3f1b858aL5-R13): Added an iframe to embed a YouTube video titled "From PDF to Smart AI — RAG Made Easy".

### Updating Description:

* [`website/content/docs/index.mdx`](diffhunk://#diff-59e53d7f7580b8f957c5aaac5e62155b01f9f24030c1ac11924e9b027baeb3c7L60-R62): Updated the description to replace `agentica` with `@agentica` and made slight modifications to the text for better clarity.