### PR TITLE
feat(cli): use choices for project option

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -22,15 +22,18 @@ import { downloadTemplateAndPlaceInProject, writeEnvKeysToDotEnv } from "../fs";
 import { detectPackageManager, installCommand, runCommand } from "../packages";
 import { execAsync, formatWithPrettier } from "../utils";
 
+export const START_TEMPLATES = [
+  "nodejs",
+  "nestjs",
+  "react",
+  "react-native",
+  "standalone",
+  "nestjs+react",
+  "nodejs+react",
+] as const satisfies readonly string[];
+
 /** supported starter templates */
-export type StarterTemplate =
-  | "nodejs"
-  | "nestjs"
-  | "react"
-  | "react-native"
-  | "standalone"
-  | "nestjs+react"
-  | "nodejs+react";
+export type StarterTemplate = typeof START_TEMPLATES[number];
 
 /**
  * Start command options

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -14,9 +14,6 @@ afterEach(() => {
 /** mock the 'start' function from './commands/start' */
 const startMock = vi.fn();
 
-/** mock the error log functions from '@clack/prompts' */
-const promptLogErrorMock = vi.fn();
-
 /** mock the intro function from '@clack/prompts' */
 const promptIntroMock = vi.fn();
 
@@ -59,13 +56,10 @@ describe("start subcommand", () => {
       start: startMock,
     }));
 
-    /* mock the 'p.log.error' function from '@clack/prompts' */
+    /* mock the intro function from '@clack/prompts' */
     vi.mock("@clack/prompts", async () => ({
       ...(await vi.importActual("@clack/prompts")),
       intro: promptIntroMock,
-      log: {
-        error: promptLogErrorMock,
-      },
     }));
   });
 
@@ -110,14 +104,13 @@ describe("start subcommand", () => {
     // override output to avoid the process to exit
     program.exitOverride();
 
-    program.parse(["node", "agentica", "start", "--project"]);
+    // Use try...catch to assert the error thrown by exitOverride
+    expect(() => {
+      program.parse(["node", "agentica", "start", "--project"]);
+    }).toThrow();
 
     // check start message is not called because of the error
     expect(startMock).not.toHaveBeenCalled();
-
-    // check the error message
-    expect(promptLogErrorMock).toHaveBeenCalledOnce();
-    expect(promptLogErrorMock.mock.calls[0][0]).toEqual(`\n❌ The value of ${picocolors.redBright("--project")} is required`);
   });
 
   it("test the start command with invalid project option", async () => {
@@ -126,13 +119,11 @@ describe("start subcommand", () => {
     // override output to avoid the process to exit
     program.exitOverride();
 
-    program.parse(["node", "agentica", "start", "--project", "invalid"]);
+    expect(() => {
+      program.parse(["node", "agentica", "start", "--project", "invalid"]);
+    }).toThrow();
 
     // check start message is not called because of the error
     expect(startMock).not.toHaveBeenCalled();
-
-    // check the error message
-    expect(promptLogErrorMock).toHaveBeenCalledOnce();
-    expect(promptLogErrorMock.mock.calls[0][0]).toEqual(`\n❌ The value of ${picocolors.redBright("--project")} is invalid`);
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -104,7 +104,6 @@ describe("start subcommand", () => {
     // override output to avoid the process to exit
     program.exitOverride();
 
-    // Use try...catch to assert the error thrown by exitOverride
     expect(() => {
       program.parse(["node", "agentica", "start", "--project"]);
     }).toThrow();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,6 @@ import process from "node:process";
 import * as p from "@clack/prompts";
 import { Command, Option } from "commander";
 import * as picocolors from "picocolors";
-import typia from "typia";
 
 import type { StarterTemplate } from "./commands/start";
 
@@ -31,7 +30,7 @@ program
   .description("Start a new project")
   .addOption(
     new Option(
-      "-p, --project",
+      "-p, --project <project>",
       "The project type",
     )
       .choices(START_TEMPLATES),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,11 @@
 import process from "node:process";
 
 import * as p from "@clack/prompts";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import * as picocolors from "picocolors";
 import typia from "typia";
 
-import type { StarterTemplate } from "./commands/start";
+import { START_TEMPLATES, type StarterTemplate } from "./commands/start";
 
 import { start } from "./commands";
 
@@ -28,9 +28,12 @@ program
 program
   .command("start")
   .description("Start a new project")
-  .option(
-    "-p, --project [nodejs|nestjs|react|nestjs+react|standalone]",
-    "The project type",
+  .addOption(
+    new Option(
+      "-p, --project",
+      "The project type",
+    )
+      .choices(START_TEMPLATES)
   )
   .action(async (options: CliOptions) => {
     if ((options.project as any) === true) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,9 +5,10 @@ import { Command, Option } from "commander";
 import * as picocolors from "picocolors";
 import typia from "typia";
 
-import { START_TEMPLATES, type StarterTemplate } from "./commands/start";
+import type { StarterTemplate } from "./commands/start";
 
 import { start } from "./commands";
+import { START_TEMPLATES } from "./commands/start";
 
 interface CliOptions {
   project?: StarterTemplate;
@@ -33,7 +34,7 @@ program
       "-p, --project",
       "The project type",
     )
-      .choices(START_TEMPLATES)
+      .choices(START_TEMPLATES),
   )
   .action(async (options: CliOptions) => {
     if ((options.project as any) === true) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,21 +37,6 @@ program
       .choices(START_TEMPLATES),
   )
   .action(async (options: CliOptions) => {
-    if ((options.project as any) === true) {
-      p.log.error(
-        `\n❌ The value of ${picocolors.redBright("--project")} is required`,
-      );
-      return;
-    }
-
-    /** check valid project type */
-    if (!typia.is<StarterTemplate | undefined>(options.project)) {
-      p.log.error(
-        `\n❌ The value of ${picocolors.redBright("--project")} is invalid`,
-      );
-      return;
-    }
-
     p.intro(`🚀 ${picocolors.blueBright("Agentica")} Setup Wizard`);
 
     await start({ template: options.project });


### PR DESCRIPTION
This pull request refactors the handling of starter templates in the CLI and enhances the `commander` program's option definition for better maintainability and type safety. The most important changes include introducing a constant array for starter templates, updating the `StarterTemplate` type to derive from this array, and improving the `commander` option definition to use `.choices()`.

### Refactoring of starter templates:

* [`packages/cli/src/commands/start.ts`](diffhunk://#diff-6858dc88bcb8c8d88063b185a5bddbe2709171731c56c401cbf793bf7ff5baa1R25-R36): Introduced a `START_TEMPLATES` constant array to list all supported starter templates and updated the `StarterTemplate` type to derive its values from this array using `typeof START_TEMPLATES[number]`. This improves maintainability by centralizing the template definitions.

### Enhancements to `commander` program:

* [`packages/cli/src/index.ts`](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL31-R36): Updated the `start` command's `--project` option to use the `.choices()` method with the `START_TEMPLATES` array, ensuring the option values are dynamically tied to the centralized template definitions. This enhances type safety and reduces redundancy.
* [`packages/cli/src/index.ts`](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL4-R8): Imported the `START_TEMPLATES` constant and updated the import statement to include `Option` from `commander`, aligning with the new `.choices()` usage.