### PR TITLE
fix(pg-vector-selector): benchmark type

### DIFF
--- a/benchmark/pg-vector-selector-benchmark/src/runShoppingBenchmark.ts
+++ b/benchmark/pg-vector-selector-benchmark/src/runShoppingBenchmark.ts
@@ -1,13 +1,13 @@
 import type { Agentica, AgenticaOperation } from "@agentica/core";
 import type { ILlmSchema, OpenApi } from "@samchon/openapi";
 
-import { AgenticaCallBenchmark } from "@agentica/benchmark";
+import { AgenticaSelectBenchmark } from "@agentica/benchmark";
 
 export interface ShoppingBenchmarkConfig<Model extends ILlmSchema.Model> {
   agent: Agentica<Model>;
 }
 
-export async function runShoppingBenchmark<Model extends ILlmSchema.Model>({ agent }: ShoppingBenchmarkConfig<Model>): Promise<AgenticaCallBenchmark<Model>> {
+export async function runShoppingBenchmark<Model extends ILlmSchema.Model>({ agent }: ShoppingBenchmarkConfig<Model>): Promise<AgenticaSelectBenchmark<Model>> {
   // DO BENCHMARK
   const find = (
     method: OpenApi.Method,
@@ -27,11 +27,11 @@ export async function runShoppingBenchmark<Model extends ILlmSchema.Model>({ age
     return found;
   };
 
-  const benchmark: AgenticaCallBenchmark<Model> = new AgenticaCallBenchmark(
+  const benchmark: AgenticaSelectBenchmark<Model> = new AgenticaSelectBenchmark(
     {
       agent,
       config: {
-        repeat: 10,
+        repeat: 100,
       },
       scenarios: [
         {


### PR DESCRIPTION
This pull request updates the `runShoppingBenchmark` function in `benchmark/pg-vector-selector-benchmark/src/runShoppingBenchmark.ts` to use a different benchmark class and modifies its configuration. The changes focus on aligning the function with the `AgenticaSelectBenchmark` class and increasing the benchmark's repeat count.

### Updates to Benchmark Class and Configuration:

* Replaced `AgenticaCallBenchmark` with `AgenticaSelectBenchmark` for both the imported class and the return type of the `runShoppingBenchmark` function to reflect the new benchmark type.
* Updated the instantiation of the benchmark object to use `AgenticaSelectBenchmark` and increased the `repeat` configuration value from `10` to `100` for more extensive testing.