### PR TITLE
fix(benchmark): add error count and fix total token usage on report format

### DIFF
--- a/packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts
+++ b/packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts
@@ -55,6 +55,7 @@ function writeIndex<Model extends ILlmSchema.Model>(result: IAgenticaSelectBench
     `    - Trial: ${events.length}`,
     `    - Success: ${events.filter(e => e.type === "success").length}`,
     `    - Failure: ${events.filter(e => e.type === "failure").length}`,
+    `    - Error: ${events.filter(e => e.type === "error").length}`,
     `    - Average Time: ${MathUtil.round(average).toLocaleString()} ms`,
     `  - Token Usage`,
     `    - Total: ${aggregate.total.toLocaleString()}`,
@@ -106,6 +107,7 @@ function writeExperimentIndex<Model extends ILlmSchema.Model>(exp: IAgenticaSele
     `    - Trial: ${exp.events.length}`,
     `    - Success: ${exp.events.filter(e => e.type === "success").length}`,
     `    - Failure: ${exp.events.filter(e => e.type === "failure").length}`,
+    `    - Error: ${exp.events.filter(e => e.type === "error").length}`,
     `    - Average Time: ${MathUtil.round(
       exp.events
         .map(
@@ -162,7 +164,7 @@ function writeExperimentEvent<Model extends ILlmSchema.Model>(event: IAgenticaSe
     ...(event.type !== "error"
       ? [
           "  - Token Usage",
-          `    - Total: ${event.usage.aggregate.toLocaleString()}`,
+          `    - Total: ${event.usage.aggregate.total.toLocaleString()}`,
           `    - Prompt`,
           `      - Total: ${event.usage.aggregate.input.total.toLocaleString()}`,
           `      - Cached: ${event.usage.aggregate.input.cached.toLocaleString()}`,


### PR DESCRIPTION
This pull request enhances the reporting capabilities of the `AgenticaSelectBenchmarkReporter` by adding error metrics and fixing a property access issue for token usage. These changes improve the clarity and accuracy of benchmark reports.

### Enhancements to reporting:

* Added a new "Error" metric to the trial and experiment summaries to track the number of error events. (`writeIndex` and `writeExperimentIndex` in `packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts`) [[1]](diffhunk://#diff-8759e5db5d9c02ac643aaba52c04b9ddd16ed7d98a099c1bc6ac8da3cca228bdR58) [[2]](diffhunk://#diff-8759e5db5d9c02ac643aaba52c04b9ddd16ed7d98a099c1bc6ac8da3cca228bdR110)

### Bug fix:

* Corrected the property access for the "Total" token usage in event reporting by explicitly accessing the `total` property of `event.usage.aggregate`. (`writeExperimentEvent` in `packages/benchmark/src/internal/AgenticaSelectBenchmarkReporter.ts`)


1.fix total token on each report

<img width="307" alt="스크린샷 2025-04-21 오후 1 45 20" src="https://github.com/user-attachments/assets/f19f0106-1e4d-4ecc-987a-222bb88c4dc0" />

original: 
<img width="385" alt="스크린샷 2025-04-21 오후 1 46 40" src="https://github.com/user-attachments/assets/1466217d-fbe2-49e9-99c0-f5275d536461" />

2. add error property

<img width="349" alt="스크린샷 2025-04-21 오후 1 45 51" src="https://github.com/user-attachments/assets/8c38eea4-78c2-47af-9eec-cc6b20e35b8a" />
