### PR TITLE
chore(chat): remove unused package

### DIFF
--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -72,8 +72,6 @@
     "@types/react-dom": "^18.3.1",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.3",
-    "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-react-refresh": "^0.4.13",
     "gh-pages": "^6.3.0",
     "globals": "^15.11.0",
     "js-yaml": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,12 +230,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.3.4(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
-      eslint-plugin-react-hooks:
-        specifier: ^5.0.0
-        version: 5.2.0(eslint@9.24.0(jiti@2.4.2))
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.13
-        version: 0.4.19(eslint@9.24.0(jiti@2.4.2))
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
@@ -11250,6 +11244,7 @@ snapshots:
   eslint-plugin-react-refresh@0.4.19(eslint@9.24.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.24.0(jiti@2.4.2)
+    optional: true
 
   eslint-plugin-react@7.37.5(eslint@9.24.0(jiti@2.4.2)):
     dependencies:


### PR DESCRIPTION
This pull request removes unused ESLint plugins related to React from the project dependencies and updates the `pnpm-lock.yaml` file accordingly. These changes help streamline the codebase and reduce unnecessary dependencies.

### Removal of unused ESLint plugins:

* [`packages/chat/package.json`](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL75-L76): Removed `eslint-plugin-react-hooks` and `eslint-plugin-react-refresh` from the `devDependencies` section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL233-L238): Removed `eslint-plugin-react-hooks` and `eslint-plugin-react-refresh` entries under `importers:` to reflect their removal from the project.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11247): Marked `eslint-plugin-react-refresh` as optional under `snapshots:` to ensure compatibility with existing snapshots while reducing its impact.