### PR TITLE
feat(website): new dev.to article link

### DIFF
--- a/website/public/articles/why-your-mcp-server-fails.html
+++ b/website/public/articles/why-your-mcp-server-fails.html
@@ -1,0 +1,24 @@
+<html>
+
+<head>
+  <title>Why your MCP server fails (how to make 100% successful MCP server)</title>
+  <meta http-equiv="refresh" content="0; url=https://dev.to/samchon/why-your-mcp-server-fails-how-to-make-100-successful-mcp-server-iem">
+  </meta>
+  <meta property="og:type" content="website">
+  <meta 
+    property="og:image"
+    content="https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Ftx6wg8zl770apwyy09a8.png">
+</head>
+
+<body>
+  <p>
+    Moving to
+    <a href="https://dev.to/samchon/why-your-mcp-server-fails-how-to-make-100-successful-mcp-server-iem">
+      Dev.to Article
+    </a>
+    due to Reddit has shadow banned the dev.to domain links.
+  </p>
+  <p>If not redirect, click the above link manually.</p>
+</body>
+
+</html>


### PR DESCRIPTION
This pull request adds a new HTML file to the `website/public/articles` directory to redirect users to an external article on Dev.to. The file includes metadata for social sharing and a fallback message for users if the automatic redirection fails.

### Added HTML file for redirection:

* [`website/public/articles/why-your-mcp-server-fails.html`](diffhunk://#diff-43029d22b314b98f1d3660d08662a4490299803599d4f4b93c074c36556ad413R1-R24): Introduced an HTML file that redirects users to a Dev.to article explaining why MCP servers fail. The file includes a `<meta>` refresh tag for automatic redirection, Open Graph metadata for better link previews, and a fallback message with a clickable link for manual redirection.