### PR TITLE
feat(core): add multi_modal interface

### DIFF
--- a/packages/core/src/Agentica.ts
+++ b/packages/core/src/Agentica.ts
@@ -1,4 +1,5 @@
 import type { ILlmSchema } from "@samchon/openapi";
+import type { ChatCompletionContentPart } from "openai/resources/chat/completions";
 
 import type { AgenticaContext } from "./context/AgenticaContext";
 import type { AgenticaOperation } from "./context/AgenticaOperation";
@@ -7,7 +8,7 @@ import type { AgenticaOperationSelection } from "./context/AgenticaOperationSele
 import type { AgenticaEvent } from "./events/AgenticaEvent";
 import type { AgenticaRequestEvent } from "./events/AgenticaRequestEvent";
 import type { AgenticaHistory } from "./histories/AgenticaHistory";
-import type { AgenticaTextHistory } from "./histories/AgenticaTextHistory";
+import type { AgenticaUserInputHistory } from "./histories/AgenticaUserInputHistory";
 import type { IAgenticaConfig } from "./structures/IAgenticaConfig";
 import type { IAgenticaController } from "./structures/IAgenticaController";
 import type { IAgenticaProps } from "./structures/IAgenticaProps";
@@ -16,13 +17,13 @@ import type { IAgenticaVendor } from "./structures/IAgenticaVendor";
 import { AgenticaTokenUsage } from "./context/AgenticaTokenUsage";
 import { AgenticaOperationComposer } from "./context/internal/AgenticaOperationComposer";
 import { AgenticaTokenUsageAggregator } from "./context/internal/AgenticaTokenUsageAggregator";
-import { createInitializeEvent, createRequestEvent, createTextEvent } from "./factory/events";
-import { createTextHistory } from "./factory/histories";
+import { createUserInputHistory } from "./factory";
+import { createInitializeEvent, createRequestEvent, createUserInputEvent } from "./factory/events";
 import { execute } from "./orchestrate/execute";
 import { AgenticaHistoryTransformer } from "./transformers/AgenticaHistoryTransformer";
 import { __map_take } from "./utils/__map_take";
 import { ChatGptCompletionMessageUtil } from "./utils/ChatGptCompletionMessageUtil";
-import { streamDefaultReaderToAsyncGenerator, StreamUtil, toAsyncGenerator } from "./utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "./utils/StreamUtil";
 
 /**
  * Agentica AI chatbot agent.
@@ -126,29 +127,25 @@ export class Agentica<Model extends ILlmSchema.Model> {
    * @param content The content to talk
    * @returns List of newly created chat prompts
    */
-  public async conversate(content: string): Promise<AgenticaHistory<Model>[]> {
-    const text: AgenticaTextHistory<"user"> = createTextHistory<"user">({
-      role: "user",
-      text: content,
+  public async conversate(content: ChatCompletionContentPart | Array<ChatCompletionContentPart>): Promise<AgenticaHistory<Model>[]> {
+    const prompt: AgenticaUserInputHistory = createUserInputHistory({
+      contents: Array.isArray(content) ? content : [content],
     });
+
     this.dispatch(
-      createTextEvent({
-        role: "user",
-        stream: toAsyncGenerator(content),
-        done: () => true,
-        get: () => content,
-        join: async () => Promise.resolve(content),
+      createUserInputEvent({
+        contents: Array.isArray(content) ? content : [content],
       }),
     ).catch(() => {});
 
     const newbie: AgenticaHistory<Model>[] = await this.executor_(
       this.getContext({
-        prompt: text,
+        prompt,
         usage: this.token_usage_,
       }),
     );
-    this.histories_.push(text, ...newbie);
-    return [text, ...newbie];
+    this.histories_.push(prompt, ...newbie);
+    return [prompt, ...newbie];
   }
 
   /**
@@ -214,7 +211,7 @@ export class Agentica<Model extends ILlmSchema.Model> {
    * @internal
    */
   public getContext(props: {
-    prompt: AgenticaTextHistory<"user">;
+    prompt: AgenticaUserInputHistory;
     usage: AgenticaTokenUsage;
   }): AgenticaContext<Model> {
     const dispatch = async (event: AgenticaEvent<Model>) => this.dispatch(event);

--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -1,11 +1,12 @@
 import type { ILlmSchema } from "@samchon/openapi";
+import type { ChatCompletionContentPart } from "openai/resources";
 
 import type { AgenticaOperationCollection } from "./context/AgenticaOperationCollection";
 import type { MicroAgenticaContext } from "./context/MicroAgenticaContext";
 import type { AgenticaRequestEvent } from "./events/AgenticaRequestEvent";
 import type { MicroAgenticaEvent } from "./events/MicroAgenticaEvent";
 import type { AgenticaExecuteHistory } from "./histories/AgenticaExecuteHistory";
-import type { AgenticaTextHistory } from "./histories/AgenticaTextHistory";
+import type { AgenticaUserInputHistory } from "./histories/AgenticaUserInputHistory";
 import type { MicroAgenticaHistory } from "./histories/MicroAgenticaHistory";
 import type { IAgenticaController } from "./structures/IAgenticaController";
 import type { IAgenticaVendor } from "./structures/IAgenticaVendor";
@@ -15,13 +16,13 @@ import type { IMicroAgenticaProps } from "./structures/IMicroAgenticaProps";
 import { AgenticaTokenUsage } from "./context/AgenticaTokenUsage";
 import { AgenticaOperationComposer } from "./context/internal/AgenticaOperationComposer";
 import { AgenticaTokenUsageAggregator } from "./context/internal/AgenticaTokenUsageAggregator";
-import { createRequestEvent, createTextEvent } from "./factory/events";
-import { createTextHistory } from "./factory/histories";
+import { createUserInputHistory } from "./factory";
+import { createRequestEvent, createUserInputEvent } from "./factory/events";
 import { call, describe } from "./orchestrate";
 import { AgenticaHistoryTransformer } from "./transformers/AgenticaHistoryTransformer";
 import { __map_take } from "./utils/__map_take";
 import { ChatGptCompletionMessageUtil } from "./utils/ChatGptCompletionMessageUtil";
-import { streamDefaultReaderToAsyncGenerator, StreamUtil, toAsyncGenerator } from "./utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "./utils/StreamUtil";
 
 /**
  * Micro AI chatbot.
@@ -107,18 +108,13 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
    * @param content The content to talk
    * @returns List of newly created histories
    */
-  public async conversate(content: string): Promise<MicroAgenticaHistory<Model>[]> {
-    const talk: AgenticaTextHistory<"user"> = createTextHistory<"user">({
-      role: "user",
-      text: content,
+  public async conversate(content: ChatCompletionContentPart | Array<ChatCompletionContentPart>): Promise<MicroAgenticaHistory<Model>[]> {
+    const talk = createUserInputHistory({
+      contents: Array.isArray(content) ? content : [content],
     });
     this.dispatch(
-      createTextEvent({
-        role: "user",
-        stream: toAsyncGenerator(content),
-        done: () => true,
-        get: () => content,
-        join: async () => Promise.resolve(content),
+      createUserInputEvent({
+        contents: Array.isArray(content) ? content : [content],
       }),
     ).catch(() => {});
 
@@ -192,7 +188,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
    * @internal
    */
   public getContext(props: {
-    prompt: AgenticaTextHistory<"user">;
+    prompt: AgenticaUserInputHistory;
     usage: AgenticaTokenUsage;
   }): MicroAgenticaContext<Model> {
     const dispatch = this.dispatch.bind(this);

--- a/packages/core/src/context/AgenticaContext.ts
+++ b/packages/core/src/context/AgenticaContext.ts
@@ -4,7 +4,7 @@ import type OpenAI from "openai";
 import type { AgenticaEvent } from "../events/AgenticaEvent";
 import type { AgenticaEventSource } from "../events/AgenticaEventSource";
 import type { AgenticaHistory } from "../histories/AgenticaHistory";
-import type { AgenticaTextHistory } from "../histories/AgenticaTextHistory";
+import type { AgenticaUserInputHistory } from "../histories/AgenticaUserInputHistory";
 import type { IAgenticaConfig } from "../structures/IAgenticaConfig";
 
 import type { AgenticaOperationCollection } from "./AgenticaOperationCollection";
@@ -80,12 +80,12 @@ export interface AgenticaContext<Model extends ILlmSchema.Model> {
   stack: AgenticaOperationSelection<Model>[];
 
   /**
-   * Text prompt of the user.
+   * The user input history.
    *
-   * Text conversation written the by user through the
+   * The user input history written the by user through the
    * {@link Agentica.conversate} function.
    */
-  prompt: AgenticaTextHistory<"user">;
+  prompt: AgenticaUserInputHistory;
 
   /**
    * Whether the agent is ready.

--- a/packages/core/src/context/MicroAgenticaContext.ts
+++ b/packages/core/src/context/MicroAgenticaContext.ts
@@ -2,7 +2,7 @@ import type { ILlmSchema } from "@samchon/openapi";
 import type OpenAI from "openai";
 
 import type { MicroAgenticaEvent } from "../events/MicroAgenticaEvent";
-import type { AgenticaTextHistory } from "../histories/AgenticaTextHistory";
+import type { AgenticaUserInputHistory } from "../histories/AgenticaUserInputHistory";
 import type { MicroAgenticaHistory } from "../histories/MicroAgenticaHistory";
 import type { IMicroAgenticaConfig } from "../structures/IMicroAgenticaConfig";
 
@@ -66,7 +66,7 @@ export interface MicroAgenticaContext<Model extends ILlmSchema.Model> {
    * Text conversation written the by user through the
    * {@link Agentica.conversate} function.
    */
-  prompt: AgenticaTextHistory<"user">;
+  prompt: AgenticaUserInputHistory;
 
   // ----
   // HANDLERS

--- a/packages/core/src/events/AgenticaEvent.ts
+++ b/packages/core/src/events/AgenticaEvent.ts
@@ -9,6 +9,7 @@ import type { AgenticaRequestEvent } from "./AgenticaRequestEvent";
 import type { AgenticaResponseEvent } from "./AgenticaResponseEvent";
 import type { AgenticaSelectEvent } from "./AgenticaSelectEvent";
 import type { AgenticaTextEvent } from "./AgenticaTextEvent";
+import type { AgenticaUserInputEvent } from "./AgenticaUserInputEvent";
 import type { AgenticaValidateEvent } from "./AgenticaValidateEvent";
 
 /**
@@ -31,7 +32,8 @@ export type AgenticaEvent<Model extends ILlmSchema.Model> =
   | AgenticaResponseEvent
   | AgenticaSelectEvent<Model>
   | AgenticaTextEvent
-  | AgenticaValidateEvent<Model>;
+  | AgenticaValidateEvent<Model>
+  | AgenticaUserInputEvent;
 export namespace AgenticaEvent {
   export type Type = AgenticaEvent<any>["type"];
   export interface Mapper<Model extends ILlmSchema.Model> {
@@ -45,6 +47,7 @@ export namespace AgenticaEvent {
     select: AgenticaSelectEvent<Model>;
     text: AgenticaTextEvent;
     validate: AgenticaValidateEvent<Model>;
+    user_input: AgenticaUserInputEvent;
   }
   export type Source =
     | "initialize"

--- a/packages/core/src/events/AgenticaTextEvent.ts
+++ b/packages/core/src/events/AgenticaTextEvent.ts
@@ -3,10 +3,8 @@ import type { IAgenticaEventJson } from "../json/IAgenticaEventJson";
 
 import type { AgenticaEventBase } from "./AgenticaEventBase";
 
-export interface AgenticaTextEvent<
-  Role extends "assistant" | "user" = "assistant" | "user",
-> extends AgenticaEventBase<"text"> {
-  role: Role;
+export interface AgenticaTextEvent extends AgenticaEventBase<"text"> {
+  role: "assistant";
   stream: AsyncGenerator<string, undefined, undefined>;
   join: () => Promise<string>;
   toJSON: () => IAgenticaEventJson.IText;

--- a/packages/core/src/events/AgenticaUserInputEvent.ts
+++ b/packages/core/src/events/AgenticaUserInputEvent.ts
@@ -1,0 +1,13 @@
+import type { ChatCompletionContentPart } from "openai/resources";
+
+import type { AgenticaUserInputHistory } from "../histories/AgenticaUserInputHistory";
+import type { IAgenticaEventJson } from "../json/IAgenticaEventJson";
+
+import type { AgenticaEventBase } from "./AgenticaEventBase";
+
+export interface AgenticaUserInputEvent extends AgenticaEventBase<"user_input"> {
+  role: "user";
+  contents: Array<ChatCompletionContentPart>;
+  toJSON: () => IAgenticaEventJson.IUserInput;
+  toHistory: () => AgenticaUserInputHistory;
+}

--- a/packages/core/src/events/MicroAgenticaEvent.ts
+++ b/packages/core/src/events/MicroAgenticaEvent.ts
@@ -6,6 +6,7 @@ import type { AgenticaExecuteEvent } from "./AgenticaExecuteEvent";
 import type { AgenticaRequestEvent } from "./AgenticaRequestEvent";
 import type { AgenticaResponseEvent } from "./AgenticaResponseEvent";
 import type { AgenticaTextEvent } from "./AgenticaTextEvent";
+import type { AgenticaUserInputEvent } from "./AgenticaUserInputEvent";
 import type { AgenticaValidateEvent } from "./AgenticaValidateEvent";
 
 /**
@@ -25,7 +26,8 @@ export type MicroAgenticaEvent<Model extends ILlmSchema.Model> =
   | AgenticaRequestEvent
   | AgenticaResponseEvent
   | AgenticaTextEvent
-  | AgenticaValidateEvent<Model>;
+  | AgenticaValidateEvent<Model>
+  | AgenticaUserInputEvent;
 export namespace MicroAgenticaEvent {
   export type Type = MicroAgenticaEvent<any>["type"];
   export interface Mapper<Model extends ILlmSchema.Model> {
@@ -36,6 +38,7 @@ export namespace MicroAgenticaEvent {
     response: AgenticaResponseEvent;
     text: AgenticaTextEvent;
     validate: AgenticaValidateEvent<Model>;
+    user_input: AgenticaUserInputEvent;
   }
   export type Source = "call" | "describe";
 }

--- a/packages/core/src/histories/AgenticaHistory.ts
+++ b/packages/core/src/histories/AgenticaHistory.ts
@@ -5,13 +5,15 @@ import type { AgenticaDescribeHistory } from "./AgenticaDescribeHistory";
 import type { AgenticaExecuteHistory } from "./AgenticaExecuteHistory";
 import type { AgenticaSelectHistory } from "./AgenticaSelectHistory";
 import type { AgenticaTextHistory } from "./AgenticaTextHistory";
+import type { AgenticaUserInputHistory } from "./AgenticaUserInputHistory";
 
 export type AgenticaHistory<Model extends ILlmSchema.Model> =
   | AgenticaCancelHistory<Model>
   | AgenticaDescribeHistory<Model>
   | AgenticaExecuteHistory<Model>
   | AgenticaSelectHistory<Model>
-  | AgenticaTextHistory;
+  | AgenticaTextHistory
+  | AgenticaUserInputHistory;
 export namespace AgenticaHistory {
   export type Type = AgenticaHistory<any>["type"];
   export interface Mapper<Model extends ILlmSchema.Model> {
@@ -20,5 +22,6 @@ export namespace AgenticaHistory {
     execute: AgenticaExecuteHistory<Model>;
     select: AgenticaSelectHistory<Model>;
     text: AgenticaTextHistory;
+    user_input: AgenticaUserInputHistory;
   }
 }

--- a/packages/core/src/histories/AgenticaTextHistory.ts
+++ b/packages/core/src/histories/AgenticaTextHistory.ts
@@ -2,9 +2,7 @@ import type { IAgenticaHistoryJson } from "../json/IAgenticaHistoryJson";
 
 import type { AgenticaHistoryBase } from "./AgenticaHistoryBase";
 
-export interface AgenticaTextHistory<
-  Role extends "assistant" | "user" = "assistant" | "user",
-> extends AgenticaHistoryBase<"text", IAgenticaHistoryJson.IText> {
-  role: Role;
+export interface AgenticaTextHistory extends AgenticaHistoryBase<"text", IAgenticaHistoryJson.IText> {
+  role: "assistant";
   text: string;
 }

--- a/packages/core/src/histories/AgenticaUserInputHistory.ts
+++ b/packages/core/src/histories/AgenticaUserInputHistory.ts
@@ -1,0 +1,10 @@
+import type { ChatCompletionContentPart } from "openai/resources/chat/completions/completions";
+
+import type { IAgenticaHistoryJson } from "../json/IAgenticaHistoryJson";
+
+import type { AgenticaHistoryBase } from "./AgenticaHistoryBase";
+
+export interface AgenticaUserInputHistory extends AgenticaHistoryBase<"user_input", IAgenticaHistoryJson.IUserInput> {
+  role: "user";
+  contents: Array<ChatCompletionContentPart>;
+}

--- a/packages/core/src/histories/MicroAgenticaHistory.ts
+++ b/packages/core/src/histories/MicroAgenticaHistory.ts
@@ -3,11 +3,13 @@ import type { ILlmSchema } from "@samchon/openapi";
 import type { AgenticaDescribeHistory } from "./AgenticaDescribeHistory";
 import type { AgenticaExecuteHistory } from "./AgenticaExecuteHistory";
 import type { AgenticaTextHistory } from "./AgenticaTextHistory";
+import type { AgenticaUserInputHistory } from "./AgenticaUserInputHistory";
 
 export type MicroAgenticaHistory<Model extends ILlmSchema.Model> =
   | AgenticaDescribeHistory<Model>
   | AgenticaExecuteHistory<Model>
-  | AgenticaTextHistory;
+  | AgenticaTextHistory
+  | AgenticaUserInputHistory;
 export namespace MicroAgenticaHistory {
   export type Type = MicroAgenticaHistory<any>["type"];
   export interface Mapper<Model extends ILlmSchema.Model> {

--- a/packages/core/src/json/IAgenticaEventJson.ts
+++ b/packages/core/src/json/IAgenticaEventJson.ts
@@ -1,4 +1,5 @@
 import type OpenAI from "openai";
+import type { ChatCompletionContentPart } from "openai/resources";
 
 import type { AgenticaEventSource } from "../events/AgenticaEventSource";
 
@@ -37,6 +38,13 @@ export namespace IAgenticaEventJson {
     describe: IDescribe;
     text: IText;
     request: IRequest;
+  }
+
+  /**
+   * Event of user input.
+   */
+  export interface IUserInput extends IBase<"user_input"> {
+    contents: Array<ChatCompletionContentPart>;
   }
 
   /**
@@ -140,7 +148,7 @@ export namespace IAgenticaEventJson {
     /**
      * Role of the orator.
      */
-    role: "assistant" | "user";
+    role: "assistant";
 
     /**
      * Conversation text.

--- a/packages/core/src/json/IAgenticaHistoryJson.ts
+++ b/packages/core/src/json/IAgenticaHistoryJson.ts
@@ -1,3 +1,5 @@
+import type { ChatCompletionContentPart } from "openai/resources/chat/completions/completions";
+
 import type { IAgenticaOperationJson } from "./IAgenticaOperationJson";
 import type { IAgenticaOperationSelectionJson } from "./IAgenticaOperationSelectionJson";
 
@@ -18,12 +20,24 @@ import type { IAgenticaOperationSelectionJson } from "./IAgenticaOperationSelect
  * @author Samchon
  */
 export type IAgenticaHistoryJson =
+  | IAgenticaHistoryJson.IUserInput
   | IAgenticaHistoryJson.IText
   | IAgenticaHistoryJson.ISelect
   | IAgenticaHistoryJson.ICancel
   | IAgenticaHistoryJson.IExecute
   | IAgenticaHistoryJson.IDescribe;
 export namespace IAgenticaHistoryJson {
+  /**
+   * User input prompt.
+   *
+   * User input prompt about the user's input.
+   */
+  export interface IUserInput extends IBase<"user_input"> {
+    /**
+     * User input.
+     */
+    contents: Array<ChatCompletionContentPart>;
+  }
   /**
    * Select prompt.
    *
@@ -107,13 +121,11 @@ export namespace IAgenticaHistoryJson {
   /**
    * Text prompt.
    */
-  export interface IText<
-    Role extends "assistant" | "user" = "assistant" | "user",
-  > extends IBase<"text"> {
+  export interface IText extends IBase<"text"> {
     /**
      * Role of the orator.
      */
-    role: Role;
+    role: "assistant";
 
     /**
      * The text content.

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -54,7 +54,7 @@ export async function call<Model extends ILlmSchema.Model>(
       // USER INPUT
       {
         role: "user",
-        content: ctx.prompt.text,
+        content: ctx.prompt.contents,
       },
       // SYSTEM PROMPT
       ...(ctx.config?.systemPrompt?.execute === null
@@ -181,13 +181,11 @@ export async function call<Model extends ILlmSchema.Model>(
       && choice.message.content.length !== 0
     ) {
       closures.push(async () => {
-        const value: AgenticaTextHistory = createTextHistory({
-          role: "assistant",
-          text: choice.message.content!,
-        });
+        const value: AgenticaTextHistory = createTextHistory(
+          { text: choice.message.content! },
+        );
         ctx.dispatch(
           createTextEvent({
-            role: "assistant",
             get: () => value.text,
             done: () => true,
             stream: toAsyncGenerator(value.text),
@@ -473,7 +471,7 @@ async function correct<Model extends ILlmSchema.Model>(
         // USER INPUT
         {
           role: "user",
-          content: ctx.prompt.text,
+          content: ctx.prompt.contents,
         },
         // TYPE CORRECTION
         ...(ctx.config?.systemPrompt?.execute === null

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -141,7 +141,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
         // USER INPUT
         {
           role: "user",
-          content: ctx.prompt.text,
+          content: ctx.prompt.contents,
         },
         // SYSTEM PROMPT
         {

--- a/packages/core/src/orchestrate/initialize.ts
+++ b/packages/core/src/orchestrate/initialize.ts
@@ -36,7 +36,7 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
         // USER INPUT
         {
           role: "user",
-          content: ctx.prompt.text,
+          content: ctx.prompt.contents,
         },
         {
           // SYSTEM PROMPT
@@ -108,7 +108,6 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
 
         ctx.dispatch(
           createTextEvent({
-            role: "assistant",
             stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
             done: () => mpsc.done(),
             get: () => textContext[choice.index]!.content,
@@ -145,10 +144,7 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
       && choice.message.content.length !== 0
     ) {
       prompts.push(
-        createTextHistory({
-          role: "assistant",
-          text: choice.message.content,
-        }),
+        createTextHistory({ text: choice.message.content }),
       );
     }
   }

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -13,7 +13,6 @@ import type { __IChatSelectFunctionsApplication } from "../context/internal/__IC
 import type { AgenticaEvent } from "../events/AgenticaEvent";
 import type { AgenticaHistory } from "../histories/AgenticaHistory";
 import type { AgenticaSelectHistory } from "../histories/AgenticaSelectHistory";
-import type { AgenticaTextHistory } from "../histories/AgenticaTextHistory";
 
 import { AgenticaConstant } from "../constants/AgenticaConstant";
 import { AgenticaDefaultPrompt } from "../constants/AgenticaDefaultPrompt";
@@ -145,7 +144,7 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
         // USER INPUT
         {
           role: "user",
-          content: ctx.prompt.text,
+          content: ctx.prompt.contents,
         },
         // SYSTEM PROMPT
         {
@@ -260,15 +259,11 @@ async function step<Model extends ILlmSchema.Model>(ctx: AgenticaContext<Model>,
       && choice.message.content != null
       && choice.message.content.length !== 0
     ) {
-      const text: AgenticaTextHistory = createTextHistory({
-        role: "assistant",
-        text: choice.message.content,
-      });
+      const text = createTextHistory({ text: choice.message.content });
       prompts.push(text);
 
       ctx.dispatch(
         createTextEvent({
-          role: "assistant",
           stream: toAsyncGenerator(text.text),
           join: async () => Promise.resolve(text.text),
           done: () => true,

--- a/packages/core/src/transformers/AgenticaEventTransformer.ts
+++ b/packages/core/src/transformers/AgenticaEventTransformer.ts
@@ -175,7 +175,6 @@ function transformText(props: {
   event: IAgenticaEventJson.IText;
 }): AgenticaTextEvent {
   return createTextEvent({
-    role: props.event.role,
     stream: toAsyncGenerator(props.event.text),
     done: () => true,
     get: () => props.event.text,


### PR DESCRIPTION
This pull request introduces a significant refactor to the `Agentica` and `MicroAgentica` chatbot systems, replacing the `AgenticaTextHistory` and `AgenticaTextEvent` constructs with `AgenticaUserInputHistory` and `AgenticaUserInputEvent`. The changes improve the handling of user input by supporting structured content parts, enhancing flexibility and functionality for chatbot interactions.

### Transition from `AgenticaTextHistory` and `AgenticaTextEvent` to `AgenticaUserInputHistory` and `AgenticaUserInputEvent`:

* **History and Event Updates**:
  - Replaced `AgenticaTextHistory` with `AgenticaUserInputHistory` across all relevant files and interfaces, including `AgenticaContext`, `MicroAgenticaContext`, and their respective `conversate` methods. This change allows for handling structured user input instead of plain text. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L10-R11) [[2]](diffhunk://#diff-8db8307cc84d1852618b218fd87e0f1ee31284644da9f0fea0adbe9f437756adL83-R88) [[3]](diffhunk://#diff-8d7573456e03fd3a53168c9d77fb55274ec2381a47ae0c7bb8bb900427626650L69-R69)
  - Replaced `AgenticaTextEvent` with `AgenticaUserInputEvent`, introducing a new event type to manage structured user input. Updated event creation logic in `createUserInputEvent`. [[1]](diffhunk://#diff-3855fd279b5450c578106a314750aa25e3678d5860d0b0a818bb7471a9845fcdL34-R36) [[2]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78R39-R54) [[3]](diffhunk://#diff-a391c3ef8535b4fe721b773166396d5dfc9dcc7fe731d0f013f10346af106ac7R1-R13)

* **Factory and Utility Changes**:
  - Added `createUserInputHistory` and `createUserInputEvent` to the factory methods, ensuring seamless creation of the new history and event types. [[1]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78R19-R24) [[2]](diffhunk://#diff-ffe98c9ddc17323da206ab3ec9a5bdea5eb03d9f302326fe024aff5f312120e9R3)
  - Updated `createTextEvent` to restrict its role to "assistant" only, reflecting its new purpose.

### Method and Interface Adjustments:

* **Conversate Method Refactor**:
  - Updated the `conversate` method in both `Agentica` and `MicroAgentica` classes to accept `ChatCompletionContentPart` or an array of such parts, enabling structured input handling. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L129-R148) [[2]](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L110-R117)
  - Modified the `getContext` methods in both classes to use `AgenticaUserInputHistory` instead of `AgenticaTextHistory`. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L217-R214) [[2]](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L195-R191)

* **Context and Event Mapping**:
  - Adjusted `AgenticaContext` and `MicroAgenticaContext` interfaces to reference `AgenticaUserInputHistory` for user input prompts. [[1]](diffhunk://#diff-8db8307cc84d1852618b218fd87e0f1ee31284644da9f0fea0adbe9f437756adL83-R88) [[2]](diffhunk://#diff-8d7573456e03fd3a53168c9d77fb55274ec2381a47ae0c7bb8bb900427626650L69-R69)
  - Updated event mapping in `AgenticaEvent` and `MicroAgenticaEvent` to include the new `user_input` event type. [[1]](diffhunk://#diff-3855fd279b5450c578106a314750aa25e3678d5860d0b0a818bb7471a9845fcdR50) [[2]](diffhunk://#diff-8db13d6934f2fb21d393ce170edcc4237066f9dd8e6b91270dd4ccc7325e315bR41)

These changes enhance the chatbot's ability to handle more complex user inputs, paving the way for richer and more dynamic interactions.