### PR TITLE
feat(cli): skip to set env step when env list length is 0(zero)

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -209,11 +209,13 @@ async function askQuestions({ template: defaultTemplate }: Pick<StartOptions, "t
       return c.envList;
     })));
 
-    const isConfirm = await p.confirm({
-      message: `Do you want to enter environment variables? (Number of environment variables to enter: ${envList.length})
+    const isConfirm = envList.length === 0
+      ? false
+      : await p.confirm({
+        message: `Do you want to enter environment variables? (Number of environment variables to enter: ${envList.length})
         ${picocolors.cyan("If you press <ctrl+c>, you can skip this step.")}`,
-      initialValue: false,
-    });
+        initialValue: false,
+      });
 
     const envInfos: EnvInfo[] = [];
 


### PR DESCRIPTION
This pull request modifies the behavior of the `askQuestions` function in `packages/cli/src/commands/start.ts` to handle cases where the `envList` is empty more gracefully. The change ensures that the confirmation prompt is skipped entirely when there are no environment variables to enter.

Key change:

* Updated the `isConfirm` logic to automatically set the value to `false` if `envList` is empty, bypassing the confirmation prompt in such cases.