### PR TITLE
chore: bump common unplugin-typia version to 2.2.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ catalogs:
       version: 5.8.3
   typia:
     '@ryoppippi/unplugin-typia':
-      specifier: ^2.1.4
-      version: 2.1.4
+      specifier: ^2.2.1
+      version: 2.2.1
     '@samchon/openapi':
       specifier: ^4.2.0
       version: 4.2.0
@@ -220,7 +220,7 @@ importers:
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.1.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.2.1(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
       '@samchon/shopping-api':
         specifier: ^0.17.0
         version: 0.17.0(@samchon/openapi@4.2.0)(typescript@5.8.3)
@@ -289,7 +289,7 @@ importers:
         version: 0.10.0
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.1.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@20.17.30)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.2.1(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@20.17.30)(lightningcss@1.29.2)(terser@5.39.0))
       '@types/node':
         specifier: ^20.14.8
         version: 20.17.30
@@ -363,7 +363,7 @@ importers:
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.1.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.2.1(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.9
@@ -2518,12 +2518,12 @@ packages:
   '@rushstack/eslint-patch@1.11.0':
     resolution: {integrity: sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==}
 
-  '@ryoppippi/unplugin-typia@2.1.4':
-    resolution: {integrity: sha512-pZtB5YhX0Egm4agc1gOn11IQiR4NnCmwvaea9kbwBImsCpR84gGayenzFDIJxkzv0U9iEBxZGUojuKnuzfpejg==}
+  '@ryoppippi/unplugin-typia@2.2.1':
+    resolution: {integrity: sha512-FPldPV9Ww50s+lJi3TodJWoGL3tqst91lmYrLG+PjwbJjzgVFSvoCbqNZht1rFCtgdmsJtzpt4J67JKwHAYjnw==}
     peerDependencies:
-      svelte: ^5.25.2
+      svelte: ^5.28.2
       typescript: '>=4.8.0 <5.9.0'
-      typia: '>=8.0.0 <9.0.0'
+      typia: '>=8.2.0'
       vite: '>=3.0.0'
     peerDependenciesMeta:
       svelte:
@@ -10124,7 +10124,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@20.17.30)(lightningcss@1.29.2)(terser@5.39.0))':
+  '@ryoppippi/unplugin-typia@2.2.1(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@20.17.30)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
       consola: 3.4.2
@@ -10143,7 +10143,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
+  '@ryoppippi/unplugin-typia@2.2.1(rollup@4.39.0)(typescript@5.8.3)(typia@9.0.1(@samchon/openapi@4.2.0)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
       consola: 3.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalogs:
     ts-patch: ^3.3.0
     typescript: ~5.8.3
   typia:
-    "@ryoppippi/unplugin-typia": ^2.1.4
+    "@ryoppippi/unplugin-typia": ^2.2.1
     "@samchon/openapi": ^4.2.0
     typia: ^9.0.1
   vite:


### PR DESCRIPTION
This pull request updates the version of `@ryoppippi/unplugin-typia` across multiple files to version `2.2.1`. The changes ensure consistency in dependency versions and align with the updated peer dependency requirements.

### Dependency Updates:
* Updated `@ryoppippi/unplugin-typia` from version `2.1.4` to `2.2.1` in `catalogs` and `importers` sections of `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL223-R223) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL292-R292) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL366-R366)
* Updated `@ryoppippi/unplugin-typia` in the `packages` section of `pnpm-lock.yaml` to reflect the new version and updated peer dependencies (`svelte` updated to `^5.28.2` and `typia` updated to `>=8.2.0`).

### Snapshot Updates:
* Updated snapshots in `pnpm-lock.yaml` to reflect the new version of `@ryoppippi/unplugin-typia` and its associated dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10127-R10127) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10146-R10146)

### Workspace Configuration:
* Updated the `@ryoppippi/unplugin-typia` version in the `catalogs` section of `pnpm-workspace.yaml` to `^2.2.1`.