### PR TITLE
feat: add bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,50 @@
+name: 🐞 Bug report
+description: Report an issue with agentica
+labels: [pending triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! If you have a usage question
+        or are unsure if this is really a bug, make sure to:
+        - Read the `README.md` of using the package
+        - Search related issues and discussions in the repository
+
+  - type: input
+    id: version
+    attributes:
+      label: agentica version
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: What platform is your computer?
+        Copy the output of `npx envinfo --system -npmPackages cleye --binaries`
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a GitHub repo that can reproduce the problem you ran into. The GitHub repo should contain GitHub Action to reproduce the error. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. [Why reproduction is required](https://antfu.me/posts/why-reproductions-are-required).
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/wrtnlabs/agentica/issues) that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: Check that this is a concrete bug.
+          required: true
+        - label: The provided reproduction is a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.
+          required: true


### PR DESCRIPTION
This pull request introduces a new bug report template for the repository to streamline the process of reporting issues and ensure that all necessary information is provided.

### New bug report template:

* [`.github/ISSUE_TEMPLATE/bug-report.yaml`](diffhunk://#diff-fe9734cc5d2a0e1916553dbc343214eab5630814c0b0a27d1370c4569afaea67R1-R50): Added a structured YAML template for bug reports, including fields for the Agentica version, platform details, bug description, reproduction steps, and validation checkboxes. This template ensures users provide a minimal reproducible example and verify there are no duplicate issues before submitting.