### PR TITLE
test(*): deprecate node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This pull request makes a minor change to the Node.js versions matrix in the GitHub Actions workflow configuration. The change removes support for Node.js version 18.x.

Node 18.x reaches its EOL on 30th April

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L13-R13): Updated the `node-version` matrix to only include versions 20.x and 22.x, removing 18.x.