### PR TITLE
fix(core): add getOperation method on MicroAgentica

### DIFF
--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -1,5 +1,6 @@
 import type { ILlmSchema } from "@samchon/openapi";
 
+import type { AgenticaOperation } from "./context/AgenticaOperation";
 import type { AgenticaOperationCollection } from "./context/AgenticaOperationCollection";
 import type { MicroAgenticaContext } from "./context/MicroAgenticaContext";
 import type { AgenticaRequestEvent } from "./events/AgenticaRequestEvent";
@@ -22,7 +23,6 @@ import { AgenticaHistoryTransformer } from "./transformers/AgenticaHistoryTransf
 import { __map_take } from "./utils/__map_take";
 import { ChatGptCompletionMessageUtil } from "./utils/ChatGptCompletionMessageUtil";
 import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "./utils/StreamUtil";
-import { AgenticaOperation } from "./context/AgenticaOperation";
 
 /**
  * Micro AI chatbot.
@@ -158,7 +158,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
     return this.props.vendor;
   }
 
-   /**
+  /**
    * Get operations.
    *
    * Get list of operations, which has capsuled the pair of controller
@@ -166,7 +166,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
    *
    * @returns List of operations
    */
-   public getOperations(): ReadonlyArray<AgenticaOperation<Model>> {
+  public getOperations(): ReadonlyArray<AgenticaOperation<Model>> {
     return this.operations_.array;
   }
 

--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -22,6 +22,7 @@ import { AgenticaHistoryTransformer } from "./transformers/AgenticaHistoryTransf
 import { __map_take } from "./utils/__map_take";
 import { ChatGptCompletionMessageUtil } from "./utils/ChatGptCompletionMessageUtil";
 import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "./utils/StreamUtil";
+import { AgenticaOperation } from "./context/AgenticaOperation";
 
 /**
  * Micro AI chatbot.
@@ -155,6 +156,18 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
    */
   public getVendor(): IAgenticaVendor {
     return this.props.vendor;
+  }
+
+   /**
+   * Get operations.
+   *
+   * Get list of operations, which has capsuled the pair of controller
+   * and function from the {@link getControllers controllers}.
+   *
+   * @returns List of operations
+   */
+   public getOperations(): ReadonlyArray<AgenticaOperation<Model>> {
+    return this.operations_.array;
   }
 
   /**


### PR DESCRIPTION
This pull request introduces a new functionality to the `MicroAgentica` class by adding support for retrieving operations encapsulated in the `AgenticaOperation` type. The changes also include importing the necessary `AgenticaOperation` module to support this functionality.

### New functionality in `MicroAgentica`:

* **Importing `AgenticaOperation`:** Added an import statement for `AgenticaOperation` in `MicroAgentica.ts` to enable the use of this type in the class. (`[packages/core/src/MicroAgentica.tsR25](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28R25)`)
* **`getOperations` method:** Introduced a new public method `getOperations` to retrieve a list of operations encapsulated as `AgenticaOperation` objects. This method provides a readonly array of operations, enhancing the class's functionality. (`[packages/core/src/MicroAgentica.tsR161-R172](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28R161-R172)`)