### PR TITLE
feat: implement micro agentica call benchmark

### DIFF
--- a/packages/benchmark/src/MicroAgenticaCallBenchmark.ts
+++ b/packages/benchmark/src/MicroAgenticaCallBenchmark.ts
@@ -1,0 +1,282 @@
+import type { MicroAgentica } from "@agentica/core";
+import type { ILlmSchema } from "@samchon/openapi";
+import type { tags } from "typia";
+
+/**
+ * @module
+ * This file contains the implementation of the AgenticaCallBenchmark class.
+ *
+ * @author Wrtn Technologies
+ */
+import { AgenticaTokenUsage } from "@agentica/core";
+import { Semaphore } from "tstl";
+
+import type { IAgenticaCallBenchmarkEvent } from "./structures/IAgenticaCallBenchmarkEvent";
+import type { IAgenticaCallBenchmarkResult } from "./structures/IAgenticaCallBenchmarkResult";
+import type { IAgenticaCallBenchmarkScenario } from "./structures/IAgenticaCallBenchmarkScenario";
+
+import { AgenticaBenchmarkPredicator } from "./internal/AgenticaBenchmarkPredicator";
+import { AgenticaCallBenchmarkReporter } from "./internal/AgenticaCallBenchmarkReporter";
+
+/**
+ * LLM function calling selection benchmark.
+ *
+ * `AgenticaCallBenchmark` is a class for the benchmark of the
+ * LLM (Large Model Language) function calling part. It utilizes both
+ * `selector` and `caller` agents and tests whether the expected
+ * {@link IAgenticaOperation operations} are properly selected and
+ * called from the given
+ * {@link IAgenticaCallBenchmarkScenario scenarios}.
+ *
+ * Note that, this `MicroAgenticaCallBenchmark` consumes a lot of time and
+ * LLM token costs because it needs the whole process of the
+ * {@link MicroAgentica} class with a lot of repetitions. If you don't want
+ * such a heavy benchmark, consider to using
+ * {@link AgenticaSelectBenchmark} instead. In my experience,
+ * {@link MicroAgentica} does not fail to function calling, so the function
+ * selection benchmark is much economical.
+ *
+ * @author Samchon
+ */
+export class MicroAgenticaCallBenchmark<Model extends ILlmSchema.Model> {
+  private agent_: MicroAgentica<Model>;
+  private scenarios_: IAgenticaCallBenchmarkScenario<Model>[];
+  private config_: MicroAgenticaCallBenchmark.IConfig;
+  private result_: IAgenticaCallBenchmarkResult<Model> | null;
+
+  /**
+   * Initializer Constructor.
+   *
+   * @param props Properties of the selection benchmark
+   */
+  public constructor(props: MicroAgenticaCallBenchmark.IProps<Model>) {
+    this.agent_ = props.agent;
+    this.scenarios_ = props.scenarios.slice();
+    this.config_ = {
+      repeat: props.config?.repeat ?? 10,
+      simultaneous: props.config?.simultaneous ?? 10,
+      consent: props.config?.consent ?? 3,
+    };
+    this.result_ = null;
+  }
+
+  /**
+   * Execute the benchmark.
+   *
+   * Execute the benchmark of the LLM function calling, and returns
+   * the result of the benchmark.
+   *
+   * If you wanna see progress of the benchmark, you can pass a callback
+   * function as the argument of the `listener`. The callback function
+   * would be called whenever a benchmark event is occurred.
+   *
+   * Also, you can publish a markdown format report by calling
+   * the {@link report} function after the benchmark execution.
+   *
+   * @param listener Callback function listening the benchmark events
+   * @returns Results of the function calling benchmark
+   */
+  public async execute(
+    listener?: (event: IAgenticaCallBenchmarkEvent<Model>) => void,
+  ): Promise<IAgenticaCallBenchmarkResult<Model>> {
+    const started_at: Date = new Date();
+    const semaphore: Semaphore = new Semaphore(this.config_.simultaneous);
+    const task = this.scenarios_.map(async (scenario) => {
+      const events: IAgenticaCallBenchmarkEvent<Model>[]
+        = await Promise.all(
+          Array.from({ length: this.config_.repeat }).map(async () => {
+            await semaphore.acquire();
+            const e: IAgenticaCallBenchmarkEvent<Model>
+              = await this.step(scenario);
+            await semaphore.release();
+
+            if (listener !== undefined) {
+              listener(e);
+            }
+
+            return e;
+          }),
+        );
+      return {
+        scenario,
+        events,
+        usage: events
+          .filter(e => e.type !== "error")
+          .map(e => e.usage)
+          .reduce((acc, cur) => AgenticaTokenUsage.plus(acc, cur), AgenticaTokenUsage.zero()),
+      };
+    });
+    const experiments: IAgenticaCallBenchmarkResult.IExperiment<Model>[]
+      = await Promise.all(task);
+    return (this.result_ = {
+      experiments,
+      started_at,
+      completed_at: new Date(),
+      usage: experiments
+        .map(p => p.usage)
+        .reduce((acc, cur) => AgenticaTokenUsage.plus(acc, cur), AgenticaTokenUsage.zero()),
+    });
+  }
+
+  /**
+   * Report the benchmark result as markdown files.
+   *
+   * Report the benchmark result {@link execute}d by
+   * `AgenticaCallBenchmark` as markdown files, and returns a dictionary
+   * object of the markdown reporting files. The key of the dictionary
+   * would be file name, and the value would be the markdown content.
+   *
+   * For reference, the markdown files are composed like below:
+   *
+   * - `./README.md`
+   * - `./scenario-1/README.md`
+   * - `./scenario-1/1.success.md`
+   * - `./scenario-1/2.failure.md`
+   * - `./scenario-1/3.error.md`
+   *
+   * @returns Dictionary of markdown files.
+   */
+  public report(): Record<string, string> {
+    if (this.result_ === null) {
+      throw new Error("Benchmark is not executed yet.");
+    }
+    return AgenticaCallBenchmarkReporter.markdown(this.result_);
+  }
+
+  private async step(
+    scenario: IAgenticaCallBenchmarkScenario<Model>,
+  ): Promise<IAgenticaCallBenchmarkEvent<Model>> {
+    const agent: MicroAgentica<Model> = this.agent_.clone();
+    const started_at: Date = new Date();
+    const success = () =>
+      AgenticaBenchmarkPredicator.success({
+        expected: scenario.expected,
+        operations: agent
+          .getHistories()
+          .filter(p => p.type === "execute")
+          .map(p => p.operation),
+        strict: false,
+      });
+    const out = (): IAgenticaCallBenchmarkEvent<Model> => {
+      const select = AgenticaBenchmarkPredicator.success({
+        expected: scenario.expected,
+        operations: agent
+          .getHistories()
+          .filter(p => p.type === "execute")
+          .map(p => p.operation),
+        strict: false,
+      });
+      const call = success();
+      return {
+        type: (call ? "success" : "failure") as "failure",
+        scenario,
+        select,
+        call,
+        prompts: agent.getHistories(),
+        usage: agent.getTokenUsage(),
+        started_at,
+        completed_at: new Date(),
+      } satisfies IAgenticaCallBenchmarkEvent.IFailure<Model>;
+    };
+
+    try {
+      await agent.conversate(scenario.text);
+      if (success()) {
+        return out();
+      }
+
+      for (let i: number = 0; i < this.config_.consent; ++i) {
+        const next: string | null
+          = await AgenticaBenchmarkPredicator.isNext(agent);
+        if (next === null) {
+          break;
+        }
+
+        await agent.conversate(next);
+        if (success()) {
+          return out();
+        }
+      }
+      return out();
+    }
+    catch (error) {
+      return {
+        type: "error",
+        scenario,
+        prompts: agent.getHistories(),
+        usage: agent.getTokenUsage(),
+        error,
+        started_at,
+        completed_at: new Date(),
+      };
+    }
+  }
+}
+export namespace MicroAgenticaCallBenchmark {
+  /**
+   * Properties of the {@link MicroAgenticaCallBenchmark} constructor.
+   */
+  export interface IProps<Model extends ILlmSchema.Model> {
+    /**
+     * AI agent instance.
+     */
+    agent: MicroAgentica<Model>;
+
+    /**
+     * List of scenarios what you expect.
+     */
+    scenarios: IAgenticaCallBenchmarkScenario<Model>[];
+
+    /**
+     * Configuration for the benchmark.
+     */
+    config?: Partial<IConfig>;
+  }
+
+  /**
+   * Configuration for the benchmark.
+   *
+   * `AgenticaSelectBenchmark.IConfig` is a data structure which
+   * represents a configuration for the benchmark, especially the
+   * capacity information of the benchmark execution.
+   */
+  export interface IConfig {
+    /**
+     * Repeat count.
+     *
+     * The number of repeating count for the benchmark execution
+     * for each scenario.
+     *
+     * @default 10
+     */
+    repeat: number & tags.Type<"uint32"> & tags.Minimum<1>;
+
+    /**
+     * Simultaneous count.
+     *
+     * The number of simultaneous count for the parallel benchmark
+     * execution.
+     *
+     * If you configure this property greater than `1`, the benchmark
+     * for each scenario would be executed in parallel in the given
+     * count.
+     *
+     * @default 10
+     */
+    simultaneous: number & tags.Type<"uint32"> & tags.Minimum<1>;
+
+    /**
+     * Number of consents.
+     *
+     * AI agent sometimes asks user to consent to the function
+     * calling, and perform it at the next step.
+     *
+     * This property represents the number of consents to allow.
+     * If the number of consents from the AI agent exceeds the
+     * configured value, the benchmark will be failed.
+     *
+     * @default 3
+     */
+    consent: number;
+  }
+}

--- a/packages/benchmark/src/index.ts
+++ b/packages/benchmark/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./AgenticaCallBenchmark";
-
+export * from "./MicroAgenticaCallBenchmark";
 export * from "./AgenticaSelectBenchmark";

--- a/packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts
+++ b/packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts
@@ -5,7 +5,7 @@
  * @author Wrtn Technologies
  */
 
-import type { Agentica, AgenticaHistory, AgenticaOperation } from "@agentica/core";
+import type { Agentica, AgenticaHistory, AgenticaOperation, MicroAgentica } from "@agentica/core";
 import type { ILlmFunction, ILlmSchema } from "@samchon/openapi";
 import type OpenAI from "openai";
 
@@ -50,7 +50,7 @@ interface IConsentProps {
   reply: string;
 }
 
-async function isNext<Model extends ILlmSchema.Model>(agent: Agentica<Model>): Promise<string | null> {
+async function isNext<Model extends ILlmSchema.Model>(agent: Agentica<Model> | MicroAgentica<Model>): Promise<string | null> {
   const last: AgenticaHistory<Model> | undefined = agent
     .getHistories()
     .at(-1);

--- a/test/src/features/test_benchmark_call_micro-agentica.ts
+++ b/test/src/features/test_benchmark_call_micro-agentica.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { AgenticaOperation } from "@agentica/core";
+import type { IHttpConnection, OpenApi } from "@samchon/openapi";
+
+import { AgenticaCallBenchmark, MicroAgenticaCallBenchmark } from "@agentica/benchmark";
+import { Agentica, MicroAgentica } from "@agentica/core";
+import { HttpLlm } from "@samchon/openapi";
+import ShoppingApi from "@samchon/shopping-api";
+import OpenAI from "openai";
+
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_benchmark_call(): Promise<void | false> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+
+  // HANDLESHAKE WITH SHOPPING BACKEND
+  const connection: IHttpConnection = {
+    host: "https://shopping-be.wrtn.ai",
+  };
+  await ShoppingApi.functional.shoppings.customers.authenticate.create(
+    connection,
+    {
+      channel_code: "samchon",
+      external_user: null,
+      href: "http://localhost:3000/@agentica/core/test_benchmark_call",
+      referrer: "http://localhost:3000/NodeJS",
+    },
+  );
+  await ShoppingApi.functional.shoppings.customers.authenticate.activate(
+    connection,
+    {
+      mobile: "821012345678",
+      name: "John Doe",
+    },
+  );
+
+  // CREATE AI AGENT
+  const agent = new MicroAgentica({
+    model: "chatgpt",
+    vendor: {
+      model: "gpt-4o-mini",
+      api: new OpenAI({
+        apiKey: TestGlobal.chatgptApiKey,
+      }),
+    },
+    controllers: [
+      {
+        protocol: "http",
+        name: "shopping",
+        application: HttpLlm.application({
+          model: "chatgpt",
+          document: await fetch(
+            "https://shopping-be.wrtn.ai/editor/swagger.json",
+          ).then(async res => res.json() as Promise<OpenApi.IDocument>),
+        }),
+        connection,
+      },
+    ],
+  });
+
+  // DO BENCHMARK
+  const find = (
+    method: OpenApi.Method,
+    path: string,
+  ): AgenticaOperation<"chatgpt"> => {
+    const found = agent
+      .getOperations()
+      .find(
+        op =>
+          op.protocol === "http"
+          && op.function.method === method
+          && op.function.path === path,
+      );
+    if (found === undefined) {
+      throw new Error(`Operation not found: ${method} ${path}`);
+    }
+    return found;
+  };
+  const benchmark = new MicroAgenticaCallBenchmark(
+    {
+      agent,
+      config: {
+        repeat: 4,
+      },
+      scenarios: [
+        {
+          name: "order",
+          text: [
+            "I wanna see every sales in the shopping mall",
+            "",
+            "And then show me the detailed information about the Macbook.",
+            "",
+            "After that, select the most expensive stock",
+            "from the Macbook, and put it into my shopping cart.",
+            "And take the shopping cart to the order.",
+            "",
+            "At last, I'll publish it by cash payment, and my address is",
+            "",
+            "  - country: South Korea",
+            "  - city/province: Seoul",
+            "  - department: Wrtn Apartment",
+            "  - Possession: 101-1411",
+          ].join("\n"),
+          expected: {
+            type: "array",
+            items: [
+              {
+                type: "standalone",
+                operation: find("patch", "/shoppings/customers/sales"),
+              },
+              {
+                type: "standalone",
+                operation: find("get", "/shoppings/customers/sales/{id}"),
+              },
+              {
+                type: "anyOf",
+                anyOf: [
+                  {
+                    type: "standalone",
+                    operation: find("post", "/shoppings/customers/orders"),
+                  },
+                  {
+                    type: "standalone",
+                    operation: find(
+                      "post",
+                      "/shoppings/customers/orders/direct",
+                    ),
+                  },
+                ],
+              },
+              {
+                type: "standalone",
+                operation: find(
+                  "post",
+                  "/shoppings/customers/orders/{orderId}/publish",
+                ),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  );
+  await benchmark.execute();
+
+  // REPORT
+  const docs: Record<string, string> = benchmark.report();
+  const root: string = `${TestGlobal.ROOT}/docs/benchmarks/call`;
+
+  await rmdir(root);
+  for (const [key, value] of Object.entries(docs)) {
+    await mkdir(path.join(root, key.split("/").slice(0, -1).join("/")));
+    await fs.promises.writeFile(path.join(root, key), value, "utf8");
+  }
+}
+
+async function mkdir(str: string) {
+  try {
+    await fs.promises.mkdir(str, {
+      recursive: true,
+    });
+  }
+  catch {}
+}
+async function rmdir(str: string) {
+  try {
+    await fs.promises.rm(str, {
+      recursive: true,
+    });
+  }
+  catch {}
+}

--- a/test/src/features/test_benchmark_micro-agentica_call_pg_vector_selector.ts
+++ b/test/src/features/test_benchmark_micro-agentica_call_pg_vector_selector.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { AgenticaOperation } from "@agentica/core";
+import type { IHttpConnection, OpenApi } from "@samchon/openapi";
+
+import { AgenticaCallBenchmark } from "@agentica/benchmark";
+import { Agentica } from "@agentica/core";
+import { BootAgenticaVectorSelector } from "@agentica/vector-selector";
+import { configurePostgresStrategy } from "@agentica/vector-selector/strategy";
+import { HttpLlm } from "@samchon/openapi";
+import ShoppingApi from "@samchon/shopping-api";
+import OpenAI from "openai";
+
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_benchmark_call_pg_vector_selector(): Promise<
+  void | false
+> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+  if (
+    !(
+      await fetch(
+        `http://localhost:${TestGlobal.connectorHivePort}/health`,
+      ).catch(() => ({ ok: false }))
+    ).ok
+  ) {
+    return false;
+  }
+  // HANDLESHAKE WITH SHOPPING BACKEND
+  const connection: IHttpConnection = {
+    host: `https://shopping-be.wrtn.ai`,
+  };
+  await ShoppingApi.functional.shoppings.customers.authenticate.create(
+    connection,
+    {
+      channel_code: "samchon",
+      external_user: null,
+      href: "http://localhost:3000/@agentica/core/test_benchmark_call_pg_vector_selector",
+      referrer: "http://localhost:3000/NodeJS",
+    },
+  );
+  await ShoppingApi.functional.shoppings.customers.authenticate.activate(
+    connection,
+    {
+      mobile: "821012345678",
+      name: "John Doe",
+    },
+  );
+
+  // CREATE AI AGENT
+  const selectorExecute = BootAgenticaVectorSelector({
+    strategy: configurePostgresStrategy<"chatgpt">({
+      host: `http://localhost:${TestGlobal.connectorHivePort}`,
+    }),
+  });
+  const newAgentica = async () =>
+    new Agentica<"chatgpt">({
+      model: "chatgpt",
+      vendor: {
+        model: "gpt-4o-mini",
+        api: new OpenAI({
+          apiKey: TestGlobal.chatgptApiKey,
+        }),
+      },
+      controllers: [
+        {
+          protocol: "http",
+          name: "shopping",
+          application: HttpLlm.application({
+            model: "chatgpt",
+            document: await fetch(
+              "https://shopping-be.wrtn.ai/editor/swagger.json",
+            ).then(async res => res.json() as Promise<OpenApi.IDocument>),
+          }),
+          connection,
+        },
+      ],
+      config: {
+        executor: {
+          select: selectorExecute,
+        },
+      },
+    });
+
+  const warming = async () => {
+    await newAgentica().then(async v => v.conversate("What can you do?"));
+  };
+  await warming();
+  const agent = await newAgentica();
+
+  // DO BENCHMARK
+  const find = (
+    method: OpenApi.Method,
+    path: string,
+  ): AgenticaOperation<"chatgpt"> => {
+    const found = agent
+      .getOperations()
+      .find(
+        op =>
+          op.protocol === "http"
+          && op.function.method === method
+          && op.function.path === path,
+      );
+    if (found === undefined) {
+      throw new Error(`Operation not found: ${method} ${path}`);
+    }
+    return found;
+  };
+  const benchmark = new AgenticaCallBenchmark(
+    {
+      agent,
+      config: {
+        repeat: 4,
+      },
+      scenarios: [
+        {
+          name: "order",
+          text: [
+            "I wanna see every sales in the shopping mall",
+            "",
+            "And then show me the detailed information about the Macbook.",
+            "",
+            "After that, select the most expensive stock",
+            "from the Macbook, and put it into my shopping cart.",
+            "And take the shopping cart to the order.",
+            "",
+            "At last, I'll publish it by cash payment, and my address is",
+            "",
+            "  - country: South Korea",
+            "  - city/province: Seoul",
+            "  - department: Wrtn Apartment",
+            "  - Possession: 101-1411",
+          ].join("\n"),
+          expected: {
+            type: "array",
+            items: [
+              {
+                type: "standalone",
+                operation: find("patch", "/shoppings/customers/sales"),
+              },
+              {
+                type: "standalone",
+                operation: find("get", "/shoppings/customers/sales/{id}"),
+              },
+              {
+                type: "anyOf",
+                anyOf: [
+                  {
+                    type: "standalone",
+                    operation: find("post", "/shoppings/customers/orders"),
+                  },
+                  {
+                    type: "standalone",
+                    operation: find(
+                      "post",
+                      "/shoppings/customers/orders/direct",
+                    ),
+                  },
+                ],
+              },
+              {
+                type: "standalone",
+                operation: find(
+                  "post",
+                  "/shoppings/customers/orders/{orderId}/publish",
+                ),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  );
+  await benchmark.execute();
+
+  // REPORT
+  const docs: Record<string, string> = benchmark.report();
+  const root: string = `${TestGlobal.ROOT}/docs/benchmarks/call`;
+
+  await rmdir(root);
+  for (const [key, value] of Object.entries(docs)) {
+    await mkdir(path.join(root, key.split("/").slice(0, -1).join("/")));
+    await fs.promises.writeFile(path.join(root, key), value, "utf8");
+  }
+}
+
+async function mkdir(str: string) {
+  try {
+    await fs.promises.mkdir(str, {
+      recursive: true,
+    });
+  }
+  catch {}
+}
+async function rmdir(str: string) {
+  try {
+    await fs.promises.rm(str, {
+      recursive: true,
+    });
+  }
+  catch {}
+}


### PR DESCRIPTION
This pull request introduces a new benchmarking class, `MicroAgenticaCallBenchmark`, for evaluating LLM function-calling performance, along with updates to integrate and test this functionality. The most important changes include the implementation of the new class, updates to existing files for compatibility, and the addition of test cases.

### New Feature Implementation:
* **`packages/benchmark/src/MicroAgenticaCallBenchmark.ts`**: Added the `MicroAgenticaCallBenchmark` class, which benchmarks the function-calling capabilities of LLMs using scenarios and configurations. Includes methods for execution, reporting results in markdown, and handling benchmark steps.

### Integration Updates:
* **`packages/benchmark/src/index.ts`**: Exported the new `MicroAgenticaCallBenchmark` class to make it accessible from the package's entry point.
* **`packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts`**: Updated the `isNext` function to support both `Agentica` and `MicroAgentica` agents, enabling compatibility with the new benchmarking class. [[1]](diffhunk://#diff-fa87426b26c98c6a97d29e6d8720e8d39cf64bb7b53bf99b9f4bc1e6e89fd5c4L8-R8) [[2]](diffhunk://#diff-fa87426b26c98c6a97d29e6d8720e8d39cf64bb7b53bf99b9f4bc1e6e89fd5c4L53-R53)

### Testing Enhancements:
* **`test/src/features/test_benchmark_call_micro-agentica.ts`**: Added a new test case to validate the functionality of `MicroAgenticaCallBenchmark`, including setup, execution, and markdown report generation.
* **`test/src/features/test_benchmark_micro-agentica_call_pg_vector_selector.ts`**: Added a related test for benchmarking with a PostgreSQL vector selector, ensuring broader coverage of benchmarking scenarios.