### PR TITLE
feat(core): update interface for abortSignal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - run: pnpm install --frozen-lockfile
-      
+
       - name: Sync README.md
         run: pnpm sync-readme
-        
+
       - name: Publish to NPM
         # we need -no-git-checks to avoid git errors https://github.com/pnpm/pnpm/issues/5894
         run: pnpm package:latest --no-git-checks --provenance --access public

--- a/packages/benchmark/src/index.ts
+++ b/packages/benchmark/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./AgenticaCallBenchmark";
-export * from "./MicroAgenticaCallBenchmark";
 export * from "./AgenticaSelectBenchmark";
+export * from "./MicroAgenticaCallBenchmark";

--- a/packages/core/src/context/AgenticaContext.ts
+++ b/packages/core/src/context/AgenticaContext.ts
@@ -88,6 +88,11 @@ export interface AgenticaContext<Model extends ILlmSchema.Model> {
   prompt: AgenticaUserInputHistory;
 
   /**
+   * Abort signal.
+   */
+  abortSignal?: AbortSignal;
+
+  /**
    * Whether the agent is ready.
    *
    * Returns a boolean value indicates whether the agent is ready to


### PR DESCRIPTION
This pull request introduces support for abort signals in the `Agentica` class to enable cancellation of asynchronous operations. Additionally, it includes a minor reordering of exports in the `index.ts` file to maintain consistency.

### Enhancements to `Agentica` class:

* Added an `abortSignal` option to the `conversate` method, allowing users to pass an `AbortSignal` to cancel ongoing operations. Updated method signature and related JSDoc comments.
* Propagated the `abortSignal` through the `getContext` method and included it in the `AgenticaContext` interface. This ensures the signal is accessible throughout the execution context. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898R231) [[2]](diffhunk://#diff-8db8307cc84d1852618b218fd87e0f1ee31284644da9f0fea0adbe9f437756adR90-R94)
* Updated internal logic to pass the `abortSignal` to the vendor options when making calls, ensuring proper cancellation support.

### Code organization:

* Reordered exports in `packages/benchmark/src/index.ts` for consistency, moving `MicroAgenticaCallBenchmark` to align alphabetically.