### PR TITLE
feat(core): description about `@ts-ignore`

### DIFF
--- a/packages/core/src/functional/assertMcpController.ts
+++ b/packages/core/src/functional/assertMcpController.ts
@@ -23,7 +23,9 @@ import type { IAgenticaController } from "../structures/IAgenticaController";
 export async function assertMcpController<Model extends ILlmSchema.Model>(props: {
   name: string;
   model: Model;
-  // @ts-ignore
+  // @ts-ignore Type checking only when `@modelcontextprotocol/sdk` is installed.
+  //            This strategy is useful for someone who does not need MCP,
+  //            so that have not installed `@modelcontextprotocol/sdk`.
   client: import("@modelcontextprotocol/sdk/client/index.d.ts").Client;
   options?: Partial<IMcpLlmApplication.IOptions<Model>>;
 }): Promise<IAgenticaController.IMcp<Model>> {

--- a/packages/core/src/functional/validateMcpController.ts
+++ b/packages/core/src/functional/validateMcpController.ts
@@ -24,7 +24,9 @@ export async function validateMcpController<
   Model extends ILlmSchema.Model,
 >(props: {
   name: string;
-  // @ts-ignore
+  // @ts-ignore Type checking only when `@modelcontextprotocol/sdk` is installed.
+  //            This strategy is useful for someone who does not need MCP,
+  //            so that have not installed `@modelcontextprotocol/sdk`.
   client: import("@modelcontextprotocol/sdk/client/index.d.ts").Client;
   model: Model;
   options?: Partial<IMcpLlmApplication.IOptions<Model>>;

--- a/packages/core/src/structures/IAgenticaController.ts
+++ b/packages/core/src/structures/IAgenticaController.ts
@@ -125,7 +125,9 @@ export namespace IAgenticaController {
     /**
      * MCP client for connection.
      */
-    // @ts-ignore
+    // @ts-ignore Type checking only when `@modelcontextprotocol/sdk` is installed.
+    //            This strategy is useful for someone who does not need MCP,
+    //            so that have not installed `@modelcontextprotocol/sdk`.
     client: import("@modelcontextprotocol/sdk/client/index.d.ts").Client;
   }
 


### PR DESCRIPTION
This pull request updates type-checking comments related to the `@modelcontextprotocol/sdk` package to clarify their purpose and improve developer experience. The changes ensure that type checking is only applied when the package is installed, making the code more flexible for users who do not require MCP functionality.

### Updates to type-checking comments:

* [`packages/core/src/functional/assertMcpController.ts`](diffhunk://#diff-aa9aebe2421bbd0dd1550507f1a67c8b60e925187d3ca595f8fc8cb768d3de8eL26-R28): Updated the `@ts-ignore` comment for the `client` property to explain that type checking is conditional on the presence of `@modelcontextprotocol/sdk`, catering to users who do not install the package.

* [`packages/core/src/functional/validateMcpController.ts`](diffhunk://#diff-5e3fae321e55035353b3287a65aa52aafb7e34b53ccd560e28f9e203512b9593L27-R29): Similar update to the `@ts-ignore` comment for the `client` property, clarifying that type checking is conditional on the SDK being installed.

* [`packages/core/src/structures/IAgenticaController.ts`](diffhunk://#diff-940724b541af593040f1d429094d8ae09e1f42051e975c0163222a409aa42a1cL128-R130): Updated the `@ts-ignore` comment for the `client` property in the `IAgenticaController` namespace to align with the same conditional type-checking strategy.