### PR TITLE
fix(cli): Simplify CLI version handling

### DIFF
--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -2,8 +2,6 @@ import UnpluginTypia from "@ryoppippi/unplugin-typia/rollup";
 import { isCI } from "std-env";
 import { defineBuildConfig } from "unbuild";
 
-import pkgJson from "./package.json";
-
 export default defineBuildConfig({
   outDir: "dist",
   entries: ["src/index.ts"],
@@ -14,9 +12,6 @@ export default defineBuildConfig({
       // plugin should be added to the first
       options.plugins.unshift(UnpluginTypia());
     },
-  },
-  replace: {
-    "process.env.AGENTICA_VERSION": JSON.stringify(pkgJson.version), // replace version from package.json on build
   },
   rollup: {
     inlineDependencies: [

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -18,22 +18,8 @@ const startMock = vi.fn();
 const promptIntroMock = vi.fn();
 
 describe("version", () => {
-  it("should return 0.0.0 as version when AGENTICA_VERSION is not set", async () => {
-    const { program } = await import("./index");
-
-    // override output to avoid the process to exit
-    program.exitOverride().action(() => {});
-
-    // using the exit override to capture the version output
-    expect(() => {
-      program.parse(["node", "agentica", "--version"]);
-    }).toThrow("0.0.0");
-  });
-
-  it("should return the version from AGENTICA_VERSION", async () => {
-    // stub the environment variable
-    vi.stubEnv("AGENTICA_VERSION", "1.2.3");
-
+  it("test the version command", async () => {
+    const { version } = await import("../package.json");
     const { program } = await import("./index");
 
     // override output to avoid the process to exit
@@ -41,7 +27,7 @@ describe("version", () => {
 
     expect(() => {
       program.parse(["node", "agentica", "--version"]);
-    }).toThrow("1.2.3");
+    }).toThrow(version);
   });
 });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,8 @@ import * as p from "@clack/prompts";
 import { Command, Option } from "commander";
 import * as picocolors from "picocolors";
 
+import { version } from "../package.json";
+
 import type { StarterTemplate } from "./commands/start";
 
 import { start } from "./commands";
@@ -13,16 +15,10 @@ interface CliOptions {
   project?: StarterTemplate;
 }
 
-/**
- * The version of the Agentica CLI
- * in production, it will be replaced by unbuild
- */
-const VERSION = process.env.AGENTICA_VERSION ?? "0.0.0";
-
 const program = new Command();
 
 program
-  .version(VERSION);
+  .version(version);
 
 // TODO: project option should be template
 program


### PR DESCRIPTION
Removes the build-time version replacement for the CLI. The version is now directly imported from `package.json` within the `src/index.ts` file.

This simplifies the build configuration and makes the version source more explicit.