### PR TITLE
qfix(website): fetch swagger on build

### DIFF
--- a/packages/chat/src/examples/shopping/ShoppingChatApplication.tsx
+++ b/packages/chat/src/examples/shopping/ShoppingChatApplication.tsx
@@ -10,30 +10,22 @@ import {
   HttpLlm,
   OpenApi,
 } from "@samchon/openapi";
-import { useEffect, useState } from "react";
 import typia from "typia";
 
 import { AgenticaChatApplication } from "../../AgenticaChatApplication";
 
-export function ShoppingChatApplication(props: ShoppingChatApplication.IProps) {
-  const [application, setApplication]
-    = useState<IHttpLlmApplication<ILlmSchema.Model> | null>(null);
-  useEffect(() => {
-    (async () => {
-      setApplication(
-        HttpLlm.application({
-          model: props.schemaModel,
-          document: OpenApi.convert(
-            await fetch(
-              "https://raw.githubusercontent.com/samchon/shopping-backend/refs/heads/master/packages/api/customer.swagger.json",
-            )
-              .then(async r => r.json() as unknown)
-              .then(v => typia.assert<Parameters<typeof OpenApi.convert>[0]>(v)),
-          ),
-        }),
-      );
-    })().catch(console.error);
-  }, []);
+export async function ShoppingChatApplication(props: ShoppingChatApplication.IProps) {
+  const application: IHttpLlmApplication<ILlmSchema.Model> | null = HttpLlm.application({
+    model: props.schemaModel,
+    document: OpenApi.convert(
+      await fetch(
+        "https://raw.githubusercontent.com/samchon/shopping-backend/refs/heads/master/packages/api/customer.swagger.json",
+      )
+        .then(async r => r.json() as unknown)
+        .then(v => typia.assert<Parameters<typeof OpenApi.convert>[0]>(v)),
+    ),
+  });
+
   if (application === null) {
     return (
       <div>


### PR DESCRIPTION
This pull request refactors the `ShoppingChatApplication` component in `packages/chat/src/examples/shopping/ShoppingChatApplication.tsx` to simplify its implementation by removing state management and side effects. The most important changes include converting the component to an `async` function and eliminating the use of `useState` and `useEffect`.

### Refactoring of `ShoppingChatApplication`:

* Converted `ShoppingChatApplication` from a stateful React component to an `async` function, removing the need for `useState` and `useEffect`. This simplifies the component's logic and improves readability. (`[[1]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL13-R18)`, `[[2]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL33-R28)`)
* Removed the asynchronous initialization logic inside `useEffect` and directly assigned the result of `HttpLlm.application` to the `application` variable within the `async` function. (`[[1]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL13-R18)`, `[[2]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL33-R28)`)