### PR TITLE
fix(website): Use Suspense for shopping chat loading

### DIFF
--- a/packages/chat/src/examples/shopping/ShoppingChatApplication.tsx
+++ b/packages/chat/src/examples/shopping/ShoppingChatApplication.tsx
@@ -1,8 +1,4 @@
-import type {
-  IHttpConnection,
-  IHttpLlmApplication,
-  ILlmSchema,
-} from "@samchon/openapi";
+import type { IHttpConnection, ILlmSchema } from "@samchon/openapi";
 import type OpenAI from "openai";
 
 import { Agentica } from "@agentica/core";
@@ -14,8 +10,19 @@ import typia from "typia";
 
 import { AgenticaChatApplication } from "../../AgenticaChatApplication";
 
+export function ShoppingChatApplicationSkeleton() {
+  return (
+    <div>
+      <h2>Loading Swagger document</h2>
+      <hr />
+      <p>Wait for a moment please.</p>
+      <p>Loading Swagger document...</p>
+    </div>
+  );
+}
+
 export async function ShoppingChatApplication(props: ShoppingChatApplication.IProps) {
-  const application: IHttpLlmApplication<ILlmSchema.Model> | null = HttpLlm.application({
+  const application = HttpLlm.application({
     model: props.schemaModel,
     document: OpenApi.convert(
       await fetch(
@@ -25,17 +32,6 @@ export async function ShoppingChatApplication(props: ShoppingChatApplication.IPr
         .then(v => typia.assert<Parameters<typeof OpenApi.convert>[0]>(v)),
     ),
   });
-
-  if (application === null) {
-    return (
-      <div>
-        <h2>Loading Swagger document</h2>
-        <hr />
-        <p>Wait for a moment please.</p>
-        <p>Loading Swagger document...</p>
-      </div>
-    );
-  }
 
   const agent: Agentica<ILlmSchema.Model> = new Agentica({
     model: props.schemaModel,

--- a/packages/chat/src/examples/shopping/index.tsx
+++ b/packages/chat/src/examples/shopping/index.tsx
@@ -10,12 +10,12 @@ import {
 } from "@mui/material";
 import ShoppingApi from "@samchon/shopping-api";
 import OpenAI from "openai";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import { VendorConfigurationMovie } from "../common/VendorConfigurationMovie";
 
-import { ShoppingChatApplication } from "./ShoppingChatApplication";
+import { ShoppingChatApplication, ShoppingChatApplicationSkeleton } from "./ShoppingChatApplication";
 
 function Application() {
   const [config, setConfig] = useState<VendorConfigurationMovie.IConfig>(
@@ -78,7 +78,9 @@ function Application() {
     >
       {next !== null
         ? (
-            <ShoppingChatApplication {...next} />
+            <Suspense fallback={<ShoppingChatApplicationSkeleton />}>
+              <ShoppingChatApplication {...next} />
+            </Suspense>
           )
         : (
             <FormControl


### PR DESCRIPTION
Extracted `ShoppingChatApplicationSkeleton` for a dedicated loading UI. Integrated `React.Suspense` in the shopping example to display this skeleton during the initial data fetching of the `ShoppingChatApplication`.

This removes the manual loading state handling within `ShoppingChatApplication`, as `HttpLlm.application` is now expected to resolve directly, and Suspense manages the fallback. This change improves user experience and component structure.