### PR TITLE
fix(chat): parallel build

### DIFF
--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -35,7 +35,7 @@
     "src"
   ],
   "scripts": {
-    "build": "npm run build:static && npm run build:lib",
+    "build": "pnpm --aggregate-output /^build:/",
     "build:static": "rimraf dist && tsc -b && vite build",
     "build:lib": "rimraf lib && tsc --project tsconfig.lib.json --emitDeclarationOnly && rollup -c",
     "dev": "vite",


### PR DESCRIPTION
This pull request updates the build script in the `packages/chat/package.json` file to streamline the build process by using `pnpm` with aggregated output.

Build process improvement:

* [`packages/chat/package.json`](diffhunk://#diff-162e61feb520f86e5b6de240f53beb7e78cc2846c0659c041848042f089a658cL38-R38): Replaced the `build` script to use `pnpm --aggregate-output /^build:/` instead of running individual `build:static` and `build:lib` scripts sequentially. This change simplifies the build process and leverages `pnpm`'s capabilities.