### PR TITLE
feat(website): parallelise pre/post build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,9 @@
     "dev": "next",
     "build": "next build",
     "prebuild": "node build/typedoc && node build/playground",
-    "postbuild": "node build/sitemap && pagefind --site .next/server/app --output-path out/_pagefind",
+    "postbuild": "pnpm --aggregate-output /^postbuild:/",
+    "postbuild:sitemap": "node build/sitemap",
+    "postbuild:pagefind": "pagefind --site .next/server/app --output-path out/_pagefind",
     "start": "next start",
     "lint": "next lint"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "prebuild": "node build/typedoc && node build/playground",
+    "prebuild": "pnpm --aggregate-output /^prebuild:/",
+    "prebuild:typedoc": "node build/typedoc",
+    "prebuild:playground": "node build/playground",
     "postbuild": "pnpm --aggregate-output /^postbuild:/",
     "postbuild:sitemap": "node build/sitemap",
     "postbuild:pagefind": "pagefind --site .next/server/app --output-path out/_pagefind",


### PR DESCRIPTION
This pull request refactors the build scripts in the `website/package.json` file to improve modularity and maintainability. The changes break down the `prebuild` and `postbuild` scripts into smaller, more focused sub-scripts and use `pnpm` for aggregating their execution.

### Build script refactoring:

* Replaced the monolithic `prebuild` script with a modular structure by introducing `prebuild:typedoc` and `prebuild:playground` sub-scripts, and updated the main `prebuild` script to aggregate these using `pnpm`. (`[website/package.jsonL8-R13](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L8-R13)`)
* Replaced the monolithic `postbuild` script with a modular structure by introducing `postbuild:sitemap` and `postbuild:pagefind` sub-scripts, and updated the main `postbuild` script to aggregate these using `pnpm`. (`[website/package.jsonL8-R13](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L8-R13)`)