### PR TITLE
feat(website): polyfill WebAssembly for `pagefind`.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,9 +614,6 @@ importers:
       nextra-theme-docs:
         specifier: ^4.2.16
         version: 4.2.17(@types/react@19.0.0)(next@15.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.2.17(acorn@8.14.1)(next@15.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      pagefind:
-        specifier: ^1.3.0
-        version: 1.3.0
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@18.3.1)
@@ -666,6 +663,9 @@ importers:
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@15.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      pagefind:
+        specifier: ^1.3.0
+        version: 1.3.0
       tailwindcss:
         specifier: ^4
         version: 4.1.3

--- a/website/app/layout.jsx
+++ b/website/app/layout.jsx
@@ -95,7 +95,10 @@ export default async function RootLayout(props) {
           data-light-mode="true"
           id="guru-widget-id"
         /> */}
-        <Script async type="text/javascript" dangerouslySetInnerHTML={{
+        <Script 
+          async  
+          type="module" 
+          dangerouslySetInnerHTML={{
           __html: `self.WebAssembly = self.WebAssembly || (await import("https://unpkg.com/polywasm@0.1.4/index.min.js")).WebAssembly`
         }} />
       </Head>

--- a/website/app/layout.jsx
+++ b/website/app/layout.jsx
@@ -95,6 +95,9 @@ export default async function RootLayout(props) {
           data-light-mode="true"
           id="guru-widget-id"
         /> */}
+        <Script async type="text/javascript" dangerouslySetInnerHTML={{
+          __html: `self.WebAssembly = self.WebAssembly || (await import("https://unpkg.com/polywasm@0.1.4/index.min.js")).WebAssembly`
+        }} />
       </Head>
       <body>
         <Layout

--- a/website/package.json
+++ b/website/package.json
@@ -42,7 +42,6 @@
     "next": "^15.2.1",
     "nextra": "^4.2.16",
     "nextra-theme-docs": "^4.2.16",
-    "pagefind": "^1.3.0",
     "prism-react-renderer": "^2.4.1",
     "react": "18.3.1",
     "react-dom": "^18.3.1",
@@ -61,6 +60,7 @@
     "@types/react": "^19.0.0",
     "eslint-config-next": "15.2.1",
     "next-sitemap": "^4.2.3",
+    "pagefind": "^1.3.0",
     "tailwindcss": "^4"
   }
 }


### PR DESCRIPTION
This pull request introduces a WebAssembly polyfill for broader browser compatibility and updates the `pagefind` dependency in the `website` project. The most important changes include adding a polyfill script to the `RootLayout` component and adjusting the `pagefind` dependency in `package.json` to resolve potential issues with dependency management.

### WebAssembly Polyfill:

* [`website/app/layout.jsx`](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99R98-R100): Added a script to load a WebAssembly polyfill (`polywasm`) dynamically, ensuring compatibility for environments where WebAssembly is not natively supported.

### Dependency Management:

* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L45): Removed and re-added the `pagefind` dependency, likely to address a versioning or configuration issue. [[1]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L45) [[2]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76R63)