### PR TITLE
feat(website): try webpack way

### DIFF
--- a/website/app/layout.jsx
+++ b/website/app/layout.jsx
@@ -95,12 +95,6 @@ export default async function RootLayout(props) {
           data-light-mode="true"
           id="guru-widget-id"
         /> */}
-        <Script 
-          async  
-          type="module" 
-          dangerouslySetInnerHTML={{
-          __html: `self.WebAssembly = self.WebAssembly || (await import("https://unpkg.com/polywasm@0.1.4/index.min.js")).WebAssembly`
-        }} />
       </Head>
       <body>
         <Layout

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -13,4 +13,11 @@ export default withNextra({
   images: {
     unoptimized: true,
   },
+  webpack: (config) => {
+    config.experiments = {
+      ...config.experiments,
+      asyncWebAssembly: true,
+    };
+    return config;
+  }
 });


### PR DESCRIPTION
This pull request makes changes to the `website` project to improve WebAssembly support by enabling experimental features in the Webpack configuration and removing unused code related to a WebAssembly polyfill.

### WebAssembly support improvements:

* [`website/next.config.ts`](diffhunk://#diff-fb5d281398dc89dbf8c238d09e6c1a8db1475f4fef749e6e48d62948caf277cfR16-R22): Added a `webpack` configuration to enable the `asyncWebAssembly` experiment, allowing the project to natively support WebAssembly modules.

### Code cleanup:

* [`website/app/layout.jsx`](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99L98-L103): Removed an unused `<Script>` block that dynamically imported a WebAssembly polyfill (`polywasm`). This cleanup eliminates unnecessary dependencies and simplifies the code.