### PR TITLE
feat(core): do not use `parallel_tool_calls`.

### DIFF
--- a/packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts
+++ b/packages/benchmark/src/internal/AgenticaBenchmarkPredicator.ts
@@ -101,7 +101,7 @@ async function isNext<Model extends ILlmSchema.Model>(agent: Agentica<Model> | M
         },
       ],
       tool_choice: "required",
-      parallel_tool_calls: false,
+      // parallel_tool_calls: false,
     },
     llmVendor.options,
   );

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -89,7 +89,7 @@ export async function call<Model extends ILlmSchema.Model>(
         }) as OpenAI.ChatCompletionTool,
     ),
     tool_choice: "auto",
-    parallel_tool_calls: false,
+    // parallel_tool_calls: false,
   });
 
   // ----
@@ -493,7 +493,7 @@ async function correct<Model extends ILlmSchema.Model>(
         name: call.operation.name,
       },
     },
-    parallel_tool_calls: false,
+    // parallel_tool_calls: false,
   });
 
   const chunks = await StreamUtil.readAll(completionStream);

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -172,7 +172,7 @@ async function step<Model extends ILlmSchema.Model>(
             name: CONTAINER.functions[0]!.name,
           },
         },
-    parallel_tool_calls: true,
+    // parallel_tool_calls: true,
   });
 
   const chunks = await StreamUtil.readAll(completionStream);

--- a/packages/core/src/orchestrate/initialize.ts
+++ b/packages/core/src/orchestrate/initialize.ts
@@ -62,7 +62,7 @@ export async function initialize<Model extends ILlmSchema.Model>(ctx: AgenticaCo
       },
     ],
     tool_choice: "auto",
-    parallel_tool_calls: false,
+    // parallel_tool_calls: false,
   });
 
   const textContext: ({

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -171,7 +171,7 @@ async function step<Model extends ILlmSchema.Model>(
             name: CONTAINER.functions[0]!.name,
           },
         },
-    parallel_tool_calls: false,
+    // parallel_tool_calls: false,
   });
 
   const chunks = await StreamUtil.readAll(completionStream);

--- a/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
+++ b/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
@@ -5,8 +5,7 @@ import type {
   ChatCompletionMessageToolCall,
 } from "openai/resources";
 
-import typia from "typia";
-
+// import typia from "typia";
 import { ByteArrayUtil } from "./ByteArrayUtil";
 import { ChatGptTokenUsageAggregator } from "./ChatGptTokenUsageAggregator";
 
@@ -14,10 +13,10 @@ function transformCompletionChunk(source: string | Uint8Array): ChatCompletionCh
   const str
       = source instanceof Uint8Array ? ByteArrayUtil.toUtf8(source) : source;
   const result: ChatCompletionChunk = JSON.parse(str) as ChatCompletionChunk;
-  const valid = typia.validate<ChatCompletionChunk>(result);
-  if (valid.success === false) {
-    console.error("Invalid ChatCompletionChunk", valid.errors);
-  }
+  // const valid = typia.validate<ChatCompletionChunk>(result);
+  // if (valid.success === false) {
+  //   console.error("Invalid ChatCompletionChunk", valid.errors);
+  // }
   return result;
 }
 

--- a/packages/vector-selector/src/select.ts
+++ b/packages/vector-selector/src/select.ts
@@ -70,7 +70,7 @@ export async function selectFunction<SchemaModel extends ILlmSchema.Model>(props
         name: "select_functions",
       },
     },
-    parallel_tool_calls: false,
+    // parallel_tool_calls: false,
     tools: [Tools.select_functions],
   })
     .then(async v => utils.StreamUtil.readAll(v))


### PR DESCRIPTION
This pull request primarily comments out the `parallel_tool_calls` configuration in multiple files and disables validation logic using `typia` in `ChatGptCompletionMessageUtil.ts`. These changes seem to focus on modifying tool call behavior and simplifying validation logic.

### Tool Call Behavior Changes:
* Commented out the `parallel_tool_calls` configuration in the following functions to presumably disable this feature:
  - `isNext` in `AgenticaBenchmarkPredicator.ts`
  - `call`, `correct`, `step`, and `initialize` in `orchestrate` module files (`call.ts`, `cancel.ts`, `initialize.ts`, `select.ts`) [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL92-R92) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL496-R496) [[3]](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148L175-R175) [[4]](diffhunk://#diff-cd69613b95454c4f1c769717b34a1413c863c2c73dd8594d4db6f69afb21c4c0L65-R65) [[5]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL174-R174)
  - `selectFunction` in `select.ts`

### Validation Logic Simplification:
* Disabled the `typia` validation logic in `ChatGptCompletionMessageUtil.ts` by commenting out the import and related validation code. This removes runtime validation of `ChatCompletionChunk` objects.