### PR TITLE
fix(core): add backoffStrategy

### DIFF
--- a/packages/core/src/Agentica.ts
+++ b/packages/core/src/Agentica.ts
@@ -283,10 +283,25 @@ export class Agentica<Model extends ILlmSchema.Model> {
       props.dispatch(event);
 
       // completion
-      const completion = await this.props.vendor.api.chat.completions.create(
-        event.body,
-        event.options,
-      );
+      const backoffStrategy = this.props.config?.backoffStrategy ?? ((props) => {
+        throw props.error;
+      });
+      const completion = await (async () => {
+        let count = 0;
+        while (true) {
+          try {
+            return await this.props.vendor.api.chat.completions.create(
+              event.body,
+              event.options,
+            );
+          }
+          catch (error) {
+            const waiting = backoffStrategy({ count, error });
+            await new Promise(resolve => setTimeout(resolve, waiting));
+            count++;
+          }
+        }
+      })();
 
       const [streamForEvent, temporaryStream] = StreamUtil.transform(
         completion.toReadableStream() as ReadableStream<Uint8Array>,

--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -263,10 +263,25 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
       props.dispatch(event);
 
       // completion
-      const completion = await this.props.vendor.api.chat.completions.create(
-        event.body,
-        event.options,
-      );
+      const backoffStrategy = this.props.config?.backoffStrategy ?? ((props) => {
+        throw props.error;
+      });
+      const completion = await (async () => {
+        let count = 0;
+        while (true) {
+          try {
+            return await this.props.vendor.api.chat.completions.create(
+              event.body,
+              event.options,
+            );
+          }
+          catch (error) {
+            const waiting = backoffStrategy({ count, error });
+            await new Promise(resolve => setTimeout(resolve, waiting));
+            count++;
+          }
+        }
+      })();
 
       const [streamForEvent, temporaryStream] = StreamUtil.transform(
         completion.toReadableStream() as ReadableStream<Uint8Array>,

--- a/packages/core/src/structures/IAgenticaConfig.ts
+++ b/packages/core/src/structures/IAgenticaConfig.ts
@@ -120,4 +120,22 @@ export interface IAgenticaConfig<Model extends ILlmSchema.Model> {
    * @default true
    */
   eliticism?: boolean;
+
+  /**
+   * Backoff strategy.
+   *
+   * If OpenAI SDK fails to connect LLM API Server, this Backoff factor
+   * would be used to retry for the next connection.
+   *
+   * If the function returns `true`, the retry would be stopped.
+   * Otherwise, the retry would be continued.
+   *
+   * @default (props) => throw props.error
+   * @returns {number} The number of milliseconds to wait before the next retry
+   * @throws {Error} If the function want to stop the retry, you can throw an error
+   */
+  backoffStrategy?: (props: {
+    count: number;
+    error: unknown;
+  }) => number;
 }

--- a/packages/core/src/structures/IAgenticaProps.ts
+++ b/packages/core/src/structures/IAgenticaProps.ts
@@ -81,4 +81,5 @@ export interface IAgenticaProps<Model extends ILlmSchema.Model> {
    * tracing would be binded to the instance.
    */
   tokenUsage?: IAgenticaTokenUsageJson | AgenticaTokenUsage | undefined;
+
 }

--- a/packages/core/src/structures/IMicroAgenticaConfig.ts
+++ b/packages/core/src/structures/IMicroAgenticaConfig.ts
@@ -79,4 +79,22 @@ export interface IMicroAgenticaConfig<Model extends ILlmSchema.Model> {
    * @default 3
    */
   retry?: number;
+
+  /**
+   * Backoff strategy.
+   *
+   * If OpenAI SDK fails to connect LLM API Server, this Backoff factor
+   * would be used to retry for the next connection.
+   *
+   * If the function returns `true`, the retry would be stopped.
+   * Otherwise, the retry would be continued.
+   *
+   * @default (props) => throw props.error
+   * @returns {number} The number of milliseconds to wait before the next retry
+   * @throws {Error} If the function want to stop the retry, you can throw an error
+   */
+  backoffStrategy?: (props: {
+    count: number;
+    error: unknown;
+  }) => number;
 }


### PR DESCRIPTION
This pull request introduces a backoff strategy to handle retries for API calls in the `Agentica` and `MicroAgentica` classes. The changes aim to improve resilience by allowing customizable retry logic when API requests fail. Key updates include adding the backoff strategy logic in the classes and extending the respective configuration interfaces to support this feature.

### Retry Logic Enhancements:

* `packages/core/src/Agentica.ts` and `packages/core/src/MicroAgentica.ts`: Introduced a retry mechanism with a configurable `backoffStrategy`. If an API call fails, the strategy determines the wait time before retrying. By default, it throws an error if no strategy is provided. [[1]](diffhunk://#diff-fd17ccaf3913505148ef799667fe621b8664f52622f44959be527d79c5109898L286-R304) [[2]](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L266-R284)

### Configuration Updates:

* `packages/core/src/structures/IAgenticaConfig.ts` and `packages/core/src/structures/IMicroAgenticaConfig.ts`: Added a `backoffStrategy` property to the configuration interfaces. This property allows users to define a function that calculates the wait time between retries based on the error and retry count. [[1]](diffhunk://#diff-78f5c15670f464c2ad6328aca816865847f2fa5a4e6880c61113bbc87f6140ebR123-R140) [[2]](diffhunk://#diff-a125baa84d53c276167b86b1059f76bc518888e2a2b31b6ed084eb37f6e9be3fR82-R99)

### Minor Changes:

* [`packages/core/src/structures/IAgenticaProps.ts`](diffhunk://#diff-b153121558c9ae303b601ce499c06b749df2cf9a0de205a15de9a5bb097f5977R84): Added a blank line for formatting consistency.