### PR TITLE
fix(core): remove console.error statement

### DIFF
--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -131,7 +131,6 @@ export async function call<Model extends ILlmSchema.Model>(
       ctx.dispatch(event);
     }
   }
-  console.error("call", executes);
   return executes;
 }
 


### PR DESCRIPTION
This pull request includes a minor change to the `call` function in `packages/core/src/orchestrate/call.ts`. The change removes a `console.error` statement that logged the `executes` variable, likely to clean up unnecessary logging.