### PR TITLE
fix(core): exact tool-calling id

### DIFF
--- a/packages/chat/src/examples/shopping/ShoppingChatApplication.tsx
+++ b/packages/chat/src/examples/shopping/ShoppingChatApplication.tsx
@@ -6,7 +6,7 @@ import {
   HttpLlm,
   OpenApi,
 } from "@samchon/openapi";
-import { Suspense, use } from "react";
+import { useEffect, useState } from "react";
 import typia from "typia";
 
 import { AgenticaChatApplication } from "../../AgenticaChatApplication";
@@ -22,59 +22,45 @@ function ShoppingChatApplicationSkeleton() {
   );
 }
 
-function AsyncAgenticaChatApplication({ agentPromise, title }: { agentPromise: Promise<Agentica<ILlmSchema.Model>>; title: string }) {
-  const agent = use(agentPromise);
-  return (
-    <AgenticaChatApplication
-      agent={agent}
-      title={title}
-    />
-  );
-}
-
 export function ShoppingChatApplication(props: ShoppingChatApplication.IProps) {
-  const getAgent = async () => {
-    const application = HttpLlm.application({
-      model: props.schemaModel,
-      document: OpenApi.convert(
-        await fetch(
-          "https://raw.githubusercontent.com/samchon/shopping-backend/refs/heads/master/packages/api/customer.swagger.json",
-        )
-          .then(async r => r.json() as unknown)
-          .then(v => typia.assert<Parameters<typeof OpenApi.convert>[0]>(v)),
-      ),
-    });
-    const agent: Agentica<ILlmSchema.Model> = new Agentica({
-      model: props.schemaModel,
-      vendor: {
-        api: props.api,
-        model: props.vendorModel,
-      },
-      controllers: [
-        {
-          protocol: "http",
-          name: "main",
-          application,
-          connection: props.connection,
+  const [agent, setAgent] = useState<null | Agentica<ILlmSchema.Model>>(null);
+  useEffect(() => {
+    (async () => {
+      const application = HttpLlm.application({
+        model: props.schemaModel,
+        document: OpenApi.convert(
+          await fetch(
+            "https://raw.githubusercontent.com/samchon/shopping-backend/refs/heads/master/packages/api/customer.swagger.json",
+          )
+            .then(async r => r.json() as unknown)
+            .then(v => typia.assert<Parameters<typeof OpenApi.convert>[0]>(v)),
+        ),
+      });
+      const agent: Agentica<ILlmSchema.Model> = new Agentica({
+        model: props.schemaModel,
+        vendor: {
+          api: props.api,
+          model: props.vendorModel,
         },
-      ],
-      config: {
-        locale: props.locale,
-      },
-    });
-    return agent;
-  };
-
-  const agentPromise = getAgent();
-
-  return (
-    <Suspense fallback={<ShoppingChatApplicationSkeleton />}>
-      <AsyncAgenticaChatApplication
-        agentPromise={agentPromise}
-        title="Agentica Shopping Chatbot"
-      />
-    </Suspense>
-  );
+        controllers: [
+          {
+            protocol: "http",
+            name: "main",
+            application,
+            connection: props.connection,
+          },
+        ],
+        config: {
+          locale: props.locale,
+        },
+      });
+      setAgent(agent);
+    })().catch(() => {});
+  }, []);
+  if (agent === null) {
+    return <ShoppingChatApplicationSkeleton />;
+  }
+  return <AgenticaChatApplication agent={agent} title="Agentica Shopping Chatbot" />;
 }
 export namespace ShoppingChatApplication {
   export interface IProps {

--- a/packages/chat/src/movies/AgenticaChatMovie.tsx
+++ b/packages/chat/src/movies/AgenticaChatMovie.tsx
@@ -3,6 +3,7 @@ import type {
   AgenticaAssistantMessageEvent,
   AgenticaDescribeEvent,
   AgenticaHistory,
+  AgenticaJsonParseErrorEvent,
   AgenticaOperationSelection,
   AgenticaSelectEvent,
   AgenticaTokenUsage,
@@ -90,6 +91,9 @@ export function AgenticaChatMovie<Model extends ILlmSchema.Model>({
   const handleValidate = (event: AgenticaValidateEvent<Model>) => {
     console.error(event);
   };
+  const handleJsonParseError = (event: AgenticaJsonParseErrorEvent<Model>) => {
+    console.error(event);
+  };
 
   // INITIALIZATION
   useEffect(() => {
@@ -101,6 +105,7 @@ export function AgenticaChatMovie<Model extends ILlmSchema.Model>({
     agent.on("select", handleSelect);
     agent.on("describe", handleDescribe);
     agent.on("validate", handleValidate);
+    agent.on("jsonParseError", handleJsonParseError);
     setTokenUsage(agent.getTokenUsage());
     return () => {
       agent.off("assistantMessage", handleAssistantMessage);
@@ -108,6 +113,7 @@ export function AgenticaChatMovie<Model extends ILlmSchema.Model>({
       agent.off("select", handleSelect);
       agent.off("describe", handleDescribe);
       agent.off("validate", handleValidate);
+      agent.off("jsonParseError", handleJsonParseError);
     };
   }, []);
 

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -7,7 +7,6 @@ import type {
 import type OpenAI from "openai";
 
 import { HttpLlm } from "@samchon/openapi";
-import { v4 } from "uuid";
 
 import type { AgenticaContext } from "../context/AgenticaContext";
 import type { AgenticaOperation } from "../context/AgenticaOperation";
@@ -90,6 +89,7 @@ export async function call<Model extends ILlmSchema.Model>(
   const completion: OpenAI.ChatCompletion = ChatGptCompletionMessageUtil.merge(chunks);
   const executes: AgenticaExecuteEvent<Model>[] = [];
 
+  const retry: number = ctx.config?.retry ?? AgenticaConstant.RETRY;
   for (const choice of completion.choices) {
     for (const tc of choice.message.tool_calls ?? []) {
       if (tc.type === "function") {
@@ -104,7 +104,7 @@ export async function call<Model extends ILlmSchema.Model>(
           operation,
           tc,
           [],
-          ctx.config?.retry ?? AgenticaConstant.RETRY,
+          retry,
         );
         ctx.dispatch(event);
         executes.push(event);
@@ -197,12 +197,11 @@ async function correctTypeError<Model extends ILlmSchema.Model>(
       },
     }),
     operation: callEvent.operation,
-    messageArguments: JSON.stringify(callEvent.arguments),
-    messageToolParam: {
-      role: "tool",
-      content: JSON.stringify(validateEvent.result.errors),
-      tool_call_id: callEvent.id,
-    } satisfies OpenAI.ChatCompletionToolMessageParam,
+    toolCall: {
+      id: callEvent.id,
+      arguments: JSON.stringify(callEvent.arguments),
+      result: JSON.stringify(validateEvent.result.errors),
+    },
     systemPrompt: ctx.config?.systemPrompt?.validate?.(previousValidationErrors.slice(0, -1))
       ?? [
         AgenticaSystemPrompt.VALIDATE,
@@ -239,8 +238,11 @@ async function correctJsonError<Model extends ILlmSchema.Model>(
       },
     }),
     operation: parseErrorEvent.operation,
-    messageArguments: parseErrorEvent.arguments,
-    messageToolParam: null,
+    toolCall: {
+      id: parseErrorEvent.id,
+      arguments: parseErrorEvent.arguments,
+      result: null,
+    },
     systemPrompt: ctx.config?.systemPrompt?.jsonParseError?.(parseErrorEvent)
       ?? AgenticaSystemPrompt.JSON_PARSE_ERROR.replace(
         "${{ERROR_MESSAGE}}",
@@ -278,8 +280,11 @@ async function correctError<Model extends ILlmSchema.Model>(
   props: {
     giveUp: () => AgenticaExecuteEvent<Model>;
     operation: AgenticaOperation<Model>;
-    messageArguments: string;
-    messageToolParam: null | OpenAI.ChatCompletionToolMessageParam;
+    toolCall: {
+      id: string;
+      arguments: string;
+      result: string | null;
+    };
     systemPrompt: string;
     life: number;
     previousValidationErrors: AgenticaValidateEvent<Model>[];
@@ -315,16 +320,20 @@ async function correctError<Model extends ILlmSchema.Model>(
         tool_calls: [
           {
             type: "function",
-            id: v4(),
+            id: props.toolCall.id,
             function: {
               name: props.operation.name,
-              arguments: props.messageArguments,
+              arguments: props.toolCall.arguments,
             },
           } satisfies OpenAI.ChatCompletionMessageToolCall,
         ],
       } satisfies OpenAI.ChatCompletionAssistantMessageParam,
-      ...(props.messageToolParam !== null
-        ? [props.messageToolParam]
+      ...(props.toolCall.result !== null
+        ? [{
+          role: "tool",
+          content: props.toolCall.result,
+          tool_call_id: props.toolCall.id,
+        } satisfies OpenAI.ChatCompletionToolMessageParam]
         : []),
       {
         role: "system",

--- a/test/src/features/rpc/test_rpc_micro_call.ts
+++ b/test/src/features/rpc/test_rpc_micro_call.ts
@@ -90,9 +90,7 @@ export async function test_rpc_micro_call(): Promise<void | false> {
   TestValidator.equals("events")(
     events.map(e => e.type),
   )([
-    "userMessage",
     "assistantMessage",
-    "userMessage",
     "call",
     "execute",
     "describe",

--- a/test/src/features/rpc/test_rpc_websocket_call.ts
+++ b/test/src/features/rpc/test_rpc_websocket_call.ts
@@ -101,10 +101,8 @@ export async function test_rpc_websocket_call(): Promise<void | false> {
   TestValidator.equals("events")(
     events.filter(e => e.type !== "cancel").map(e => e.type),
   )([
-    "userMessage",
     "initialize",
     "assistantMessage",
-    "userMessage",
     "select",
     "call",
     "execute",

--- a/test/src/features/rpc/test_rpc_websocket_initialize.ts
+++ b/test/src/features/rpc/test_rpc_websocket_initialize.ts
@@ -36,6 +36,11 @@ export async function test_rpc_websocket_initialize(): Promise<void | false> {
           apiKey: TestGlobal.chatgptApiKey,
         }),
       },
+      config: {
+        executor: {
+          initialize: true,
+        },
+      },
       controllers: [],
     });
     await acceptor.accept(

--- a/test/src/features/test_json_parse_error_correction.ts
+++ b/test/src/features/test_json_parse_error_correction.ts
@@ -1,0 +1,69 @@
+import type { AgenticaExecuteEvent, AgenticaJsonParseErrorEvent } from "@agentica/core";
+
+import { Agentica } from "@agentica/core";
+import { TestValidator } from "@nestia/e2e";
+import OpenAI from "openai";
+import typia from "typia";
+import { v4 } from "uuid";
+
+import { BbsArticleService } from "../internal/BbsArticleService";
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_json_parse_error_correction(): Promise<void | false> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+
+  const agent: Agentica<"chatgpt"> = new Agentica({
+    model: "chatgpt",
+    vendor: {
+      model: "gpt-4o-mini",
+      api: new OpenAI({
+        apiKey: TestGlobal.chatgptApiKey,
+      }),
+    },
+    controllers: [
+      {
+        protocol: "class",
+        name: "bbs",
+        application: typia.llm.application<BbsArticleService, "chatgpt">(),
+        execute: new BbsArticleService(),
+      },
+    ],
+  });
+
+  let polluted: boolean = false;
+  let executeEvent: AgenticaExecuteEvent<"chatgpt"> | null = null;
+
+  agent.on("call", (event) => {
+    if (polluted === true) {
+      return;
+    }
+    const jsonParseErrorEvent: AgenticaJsonParseErrorEvent<"chatgpt"> = {
+      type: "jsonParseError",
+      id: v4(),
+      created_at: new Date().toISOString(),
+      operation: event.operation,
+      arguments: JSON.stringify(event.arguments).slice(0, -1),
+      errorMessage: "Unexpected token '}' in JSON at last position",
+    };
+    for (const key of Object.keys(event.arguments)) {
+      delete (event as Record<string, any>)[key];
+    }
+    Object.assign(event, jsonParseErrorEvent);
+    polluted = true;
+  });
+  agent.on("execute", (event) => {
+    executeEvent = event;
+  });
+
+  await agent.conversate(`
+    Create an article like below:
+    
+    - title: Hello World
+    - body: Hello, my name is John Doe
+    - thumbnail: null
+    `);
+  TestValidator.equals("polluted")(polluted)(true);
+  TestValidator.equals("executeEvent")(executeEvent !== null)(true);
+}

--- a/test/src/features/test_validate_correction.ts
+++ b/test/src/features/test_validate_correction.ts
@@ -1,0 +1,66 @@
+import type { AgenticaExecuteEvent, AgenticaValidateEvent } from "@agentica/core";
+
+import { Agentica } from "@agentica/core";
+import { TestValidator } from "@nestia/e2e";
+import OpenAI from "openai";
+import typia from "typia";
+
+import { BbsArticleService } from "../internal/BbsArticleService";
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_validate_correction(): Promise<void | false> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+
+  const agent: Agentica<"chatgpt"> = new Agentica({
+    model: "chatgpt",
+    vendor: {
+      model: "gpt-4o-mini",
+      api: new OpenAI({
+        apiKey: TestGlobal.chatgptApiKey,
+      }),
+    },
+    controllers: [
+      {
+        protocol: "class",
+        name: "bbs",
+        application: typia.llm.application<BbsArticleService, "chatgpt">(),
+        execute: new BbsArticleService(),
+      },
+    ],
+  });
+
+  let polluted: boolean = false;
+  let validateEvent: AgenticaValidateEvent<"chatgpt"> | null = null;
+  let executeEvent: AgenticaExecuteEvent<"chatgpt"> | null = null;
+
+  agent.on("call", (event) => {
+    if (polluted === true) {
+      return;
+    }
+    const input = event.arguments.input;
+    typia.assertGuard<{ body: string }>(input);
+    input.body = {
+      data: input.body,
+    } as unknown as string;
+    polluted = true;
+  });
+  agent.on("validate", (event) => {
+    validateEvent = event;
+  });
+  agent.on("execute", (event) => {
+    executeEvent = event;
+  });
+
+  await agent.conversate(`
+    Create an article like below:
+
+      - title: Hello World
+      - body: Hello, my name is John Doe
+      - thumbnail: null
+  `);
+  TestValidator.equals("polluted")(polluted)(true);
+  TestValidator.equals("validateEvent")(validateEvent !== null)(true);
+  TestValidator.equals("executeEvent")(executeEvent !== null)(true);
+}


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve error handling, simplify code, and enhance the shopping chat application. The most significant updates involve replacing the `Suspense`-based asynchronous handling in the shopping chat application with `useState` and `useEffect`, adding support for handling JSON parse errors in the movie chat application, and refactoring tool call handling in the orchestration logic.

### Changes to the shopping chat application:

* Replaced the `Suspense`-based asynchronous handling with `useState` and `useEffect` for managing the agent's state. This change simplifies the logic and removes the need for the `AsyncAgenticaChatApplication` component. (`packages/chat/src/examples/shopping/ShoppingChatApplication.tsx`, [[1]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL9-R9) [[2]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL25-R28) [[3]](diffhunk://#diff-0742588351fe4c2a6be54764b634bd9616b8a27cfe8e0642fcf6741046c29b0dL65-R63)

### Enhancements to error handling in the movie chat application:

* Added support for handling `AgenticaJsonParseErrorEvent` by introducing a new event listener (`handleJsonParseError`) and ensuring proper cleanup during unmounting. (`packages/chat/src/movies/AgenticaChatMovie.tsx`, [[1]](diffhunk://#diff-36e4cfdf39ba62466600231cde9f36e7ea1723fd1b39aab8e6915d255c3ed45fR6) [[2]](diffhunk://#diff-36e4cfdf39ba62466600231cde9f36e7ea1723fd1b39aab8e6915d255c3ed45fR94-R96) [[3]](diffhunk://#diff-36e4cfdf39ba62466600231cde9f36e7ea1723fd1b39aab8e6915d255c3ed45fR108-R116)

### Refactoring tool call handling in orchestration logic:

* Replaced individual properties (`messageArguments`, `messageToolParam`) with a unified `toolCall` object to simplify and standardize the handling of tool call data. (`packages/core/src/orchestrate/call.ts`, [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL200-R204) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL242-R245) [[3]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL281-R287)
* Updated the logic for constructing tool messages to use the `toolCall` object, ensuring consistency and reducing redundancy. (`packages/core/src/orchestrate/call.ts`, [packages/core/src/orchestrate/call.tsL318-R336](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL318-R336))

### Other minor updates:

* Removed the unused `uuid` import from the orchestration logic file. (`packages/core/src/orchestrate/call.ts`, [packages/core/src/orchestrate/call.tsL10](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL10))
* Introduced a local variable `retry` to store retry configuration, improving readability. (`packages/core/src/orchestrate/call.ts`, [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eR92) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL107-R107)