### PR TITLE
feat(core): `complementValidationError` for `undefined` values.

### DIFF
--- a/packages/core/src/factory/events.ts
+++ b/packages/core/src/factory/events.ts
@@ -22,6 +22,8 @@ import type { AgenticaUserMessageContent } from "../histories";
 import type { AgenticaExecuteHistory } from "../histories/AgenticaExecuteHistory";
 import type { IAgenticaEventJson } from "../json/IAgenticaEventJson";
 
+import { complementValidationError } from "../orchestrate/internal/completeValidationError";
+
 import {
   createExecuteHistory,
   createSelectHistory,
@@ -135,6 +137,7 @@ export function createValidateEvent<Model extends ILlmSchema.Model>(props: {
   operation: AgenticaOperation<Model>;
   result: IValidation.IFailure;
 }): AgenticaValidateEvent<Model> {
+  complementValidationError(props.result);
   const created_at: string = new Date().toISOString();
   return {
     type: "validate",

--- a/packages/core/src/orchestrate/internal/completeValidationError.ts
+++ b/packages/core/src/orchestrate/internal/completeValidationError.ts
@@ -1,0 +1,22 @@
+import type { IValidation } from "typia";
+
+export function complementValidationError(
+  check: IValidation.IFailure,
+): void {
+  for (const error of check.errors) {
+    if (error.value !== undefined) {
+      continue;
+    }
+    const description: string = [
+      "> You AI has not defined the value (\`undefined\`).",
+      ">",
+      `> Please fill the \`${error.expected}\` typed value at the next time.`,
+    ].join("\n");
+    if (error.description === undefined || error.description.length === 0) {
+      error.description = description;
+    }
+    else {
+      error.description += `\n\n${description}`;
+    }
+  }
+}

--- a/packages/core/src/orchestrate/internal/completeValidationError.ts
+++ b/packages/core/src/orchestrate/internal/completeValidationError.ts
@@ -8,7 +8,7 @@ export function complementValidationError(
       continue;
     }
     const description: string = [
-      "> You AI has not defined the value (\`undefined\`).",
+      "> You AI have not defined the value (\`undefined\`).",
       ">",
       `> Please fill the \`${error.expected}\` typed value at the next time.`,
     ].join("\n");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,11 @@ catalogs:
       specifier: ^2.6.4
       version: 2.6.4
     '@samchon/openapi':
-      specifier: ^4.4.1
-      version: 4.4.1
+      specifier: ^4.5.0
+      version: 4.5.0
     typia:
-      specifier: ^9.4.0
-      version: 9.4.0
+      specifier: ^9.5.0
+      version: 9.5.0
   vite:
     vitest:
       specifier: ^3.0.9
@@ -100,7 +100,7 @@ importers:
         version: link:../../packages/vector-selector
       '@samchon/shopping-api':
         specifier: ^0.17.0
-        version: 0.17.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 0.17.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
       better-sqlite3:
         specifier: ^11.9.1
         version: 11.9.1
@@ -115,11 +115,11 @@ importers:
         version: 0.1.7-alpha.2
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -149,7 +149,7 @@ importers:
         version: link:../core
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       openai:
         specifier: catalog:libs
         version: 5.2.0(zod@3.24.2)
@@ -158,7 +158,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -204,7 +204,7 @@ importers:
         version: 6.4.10(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -225,7 +225,7 @@ importers:
         version: 1.0.2
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       uuid:
         specifier: ^11.0.5
         version: 11.1.0
@@ -241,10 +241,10 @@ importers:
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.5.0(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
       '@samchon/shopping-api':
         specifier: ^0.17.0
-        version: 0.17.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 0.17.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -317,7 +317,7 @@ importers:
         version: 0.11.0
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))(vite@5.4.17(@types/node@24.0.1)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.5.0(typescript@5.8.3))(vite@5.4.17(@types/node@24.0.1)(lightningcss@1.29.2)(terser@5.39.0))
       '@types/node':
         specifier: ^24.0.1
         version: 24.0.1
@@ -356,7 +356,7 @@ importers:
         version: 5.8.3
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       unbuild:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.8.3)
@@ -368,13 +368,13 @@ importers:
     dependencies:
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       tstl:
         specifier: catalog:libs
         version: 3.0.0
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       uuid:
         specifier: ^11.0.4
         version: 11.1.0
@@ -393,7 +393,7 @@ importers:
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
       '@ryoppippi/unplugin-typia':
         specifier: catalog:typia
-        version: 2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
+        version: 2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.5.0(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))
       '@types/node':
         specifier: ^22.13.9
         version: 22.13.9
@@ -441,10 +441,10 @@ importers:
         version: link:../core
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       '@rollup/plugin-terser':
         specifier: ^0.4.4
@@ -454,7 +454,7 @@ importers:
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
       '@samchon/shopping-api':
         specifier: ^0.17.0
-        version: 0.17.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 0.17.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.9
@@ -481,7 +481,7 @@ importers:
         version: 1.8.0
       '@wrtnlabs/connector-hive-api':
         specifier: ^1.5.0
-        version: 1.5.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 1.5.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
       better-sqlite3:
         specifier: ^11.9.1
         version: 11.9.1
@@ -506,7 +506,7 @@ importers:
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -554,10 +554,10 @@ importers:
         version: 6.0.1
       '@samchon/openapi':
         specifier: catalog:typia
-        version: 4.4.1
+        version: 4.5.0
       '@samchon/shopping-api':
         specifier: ^0.17.0
-        version: 0.17.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 0.17.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
       '@wrtnlabs/calculator-mcp':
         specifier: catalog:mcp
         version: 0.2.1
@@ -581,7 +581,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:typia
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -2576,8 +2576,8 @@ packages:
       vite:
         optional: true
 
-  '@samchon/openapi@4.4.1':
-    resolution: {integrity: sha512-RMcHrR1Atw9XUhgMh1EAt81ZBnMXiOIEET7aGpW3c4PVUqJyCm8F5yFjWIp81yicGn5IgzkrOz68F4sSeAitew==}
+  '@samchon/openapi@4.5.0':
+    resolution: {integrity: sha512-zowWJBjoKC7PUjHGIGUz6Ka3UFkvHagJ/LrdW8hGMp+4JlKmyuN9BPggK+VnH5bf8V68fPqSGVLZppcFQDBNPQ==}
 
   '@samchon/shopping-api@0.17.0':
     resolution: {integrity: sha512-aGDCAD9IhXnFKEhxn2qW5W8bu7DPXtDzabuX0I69vnQrrb/c3FVIqQAaF69d+Fd7jxF/iVguouCm4YdvjdmaCg==}
@@ -7675,18 +7675,17 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.3.1:
-    resolution: {integrity: sha512-a3rqaWE3j5ynK3nmBPEMngLfVP7FH3OrgC4xO4A4QQdcgdVL/nxTxdEqYuEjRCdcOgZCIqOt3CNoQaorOITArg==}
-    hasBin: true
-    peerDependencies:
-      '@samchon/openapi': '>=4.3.1 <5.0.0'
-      typescript: '>=4.8.0 <5.9.0'
-
   typia@9.4.0:
     resolution: {integrity: sha512-LfnK5xYvTJxBzAK40uU4TlE/1hRZAqGWWTivSYraGIDZAu4BJbPxNjtfzUIV71P30Le8ZpXMyYWbzHoBbApghQ==}
     hasBin: true
     peerDependencies:
       '@samchon/openapi': '>=4.4.1 <5.0.0'
+      typescript: '>=4.8.0 <5.9.0'
+
+  typia@9.5.0:
+    resolution: {integrity: sha512-HVQ5BR95NAmlEO+NGRqKz+EOEXktAqjKdelhms1rIj68mdDI1TzA7MUfNa4D6Ois95PcDdCgq9gwZiO+HXFC/g==}
+    hasBin: true
+    peerDependencies:
       typescript: '>=4.8.0 <5.9.0'
 
   uc.micro@2.1.0:
@@ -9638,15 +9637,15 @@ snapshots:
 
   '@nestia/e2e@6.0.1': {}
 
-  '@nestia/fetcher@6.0.1(@samchon/openapi@4.4.1)(typia@9.3.1(@samchon/openapi@4.4.1)(typescript@5.8.3))':
+  '@nestia/fetcher@6.0.1(@samchon/openapi@4.5.0)(typia@9.4.0(@samchon/openapi@4.5.0)(typescript@5.8.3))':
     dependencies:
-      '@samchon/openapi': 4.4.1
-      typia: 9.3.1(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      '@samchon/openapi': 4.5.0
+      typia: 9.4.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
 
-  '@nestia/fetcher@6.0.1(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
+  '@nestia/fetcher@6.0.1(@samchon/openapi@4.5.0)(typia@9.5.0(typescript@5.8.3))':
     dependencies:
-      '@samchon/openapi': 4.4.1
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      '@samchon/openapi': 4.5.0
+      typia: 9.5.0(typescript@5.8.3)
 
   '@next/env@13.5.11': {}
 
@@ -10190,7 +10189,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@ryoppippi/unplugin-typia@2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
+  '@ryoppippi/unplugin-typia@2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.5.0(typescript@5.8.3))(vite@5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
       bun-only: 0.0.1
@@ -10203,14 +10202,14 @@ snapshots:
       pkg-types: 2.1.0
       type-fest: 4.39.1
       typescript: 5.8.3
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      typia: 9.5.0(typescript@5.8.3)
       unplugin: 2.2.2
     optionalDependencies:
       vite: 5.4.17(@types/node@22.13.9)(lightningcss@1.29.2)(terser@5.39.0)
     transitivePeerDependencies:
       - rollup
 
-  '@ryoppippi/unplugin-typia@2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))(vite@5.4.17(@types/node@24.0.1)(lightningcss@1.29.2)(terser@5.39.0))':
+  '@ryoppippi/unplugin-typia@2.6.4(rollup@4.39.0)(typescript@5.8.3)(typia@9.5.0(typescript@5.8.3))(vite@5.4.17(@types/node@24.0.1)(lightningcss@1.29.2)(terser@5.39.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
       bun-only: 0.0.1
@@ -10223,19 +10222,19 @@ snapshots:
       pkg-types: 2.1.0
       type-fest: 4.39.1
       typescript: 5.8.3
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      typia: 9.5.0(typescript@5.8.3)
       unplugin: 2.2.2
     optionalDependencies:
       vite: 5.4.17(@types/node@24.0.1)(lightningcss@1.29.2)(terser@5.39.0)
     transitivePeerDependencies:
       - rollup
 
-  '@samchon/openapi@4.4.1': {}
+  '@samchon/openapi@4.5.0': {}
 
-  '@samchon/shopping-api@0.17.0(@samchon/openapi@4.4.1)(typescript@5.8.3)':
+  '@samchon/shopping-api@0.17.0(@samchon/openapi@4.5.0)(typescript@5.8.3)':
     dependencies:
-      '@nestia/fetcher': 6.0.1(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      '@nestia/fetcher': 6.0.1(@samchon/openapi@4.5.0)(typia@9.5.0(typescript@5.8.3))
+      typia: 9.5.0(typescript@5.8.3)
       uuid: 11.1.0
     transitivePeerDependencies:
       - '@samchon/openapi'
@@ -11221,11 +11220,11 @@ snapshots:
 
   '@wrtnlabs/calculator-mcp@0.2.1': {}
 
-  '@wrtnlabs/connector-hive-api@1.5.0(@samchon/openapi@4.4.1)(typescript@5.8.3)':
+  '@wrtnlabs/connector-hive-api@1.5.0(@samchon/openapi@4.5.0)(typescript@5.8.3)':
     dependencies:
-      '@nestia/fetcher': 6.0.1(@samchon/openapi@4.4.1)(typia@9.3.1(@samchon/openapi@4.4.1)(typescript@5.8.3))
+      '@nestia/fetcher': 6.0.1(@samchon/openapi@4.5.0)(typia@9.4.0(@samchon/openapi@4.5.0)(typescript@5.8.3))
       tgrid: 1.1.0
-      typia: 9.3.1(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      typia: 9.4.0(@samchon/openapi@4.5.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@samchon/openapi'
       - bufferutil
@@ -16626,9 +16625,9 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typia@9.3.1(@samchon/openapi@4.4.1)(typescript@5.8.3):
+  typia@9.4.0(@samchon/openapi@4.5.0)(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 4.4.1
+      '@samchon/openapi': 4.5.0
       '@standard-schema/spec': 1.0.0
       commander: 10.0.1
       comment-json: 4.2.5
@@ -16637,9 +16636,9 @@ snapshots:
       randexp: 0.5.3
       typescript: 5.8.3
 
-  typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3):
+  typia@9.5.0(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 4.4.1
+      '@samchon/openapi': 4.5.0
       '@standard-schema/spec': 1.0.0
       commander: 10.0.1
       comment-json: 4.2.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,8 @@ catalogs:
     typescript: ~5.8.3
   typia:
     "@ryoppippi/unplugin-typia": ^2.6.4
-    "@samchon/openapi": ^4.4.1
-    typia: ^9.4.0
+    "@samchon/openapi": ^4.5.0
+    typia: ^9.5.0
   vite:
     vitest: ^3.0.9
 onlyBuiltDependencies:


### PR DESCRIPTION
This pull request introduces a new utility function for handling validation errors and updates several dependencies in the project. The most significant changes include adding the `complementValidationError` function to enhance error descriptions, integrating it into the event creation process, and upgrading key dependencies such as `@samchon/openapi` and `typia`.

### New functionality for validation errors:
* [`packages/core/src/orchestrate/internal/completeValidationError.ts`](diffhunk://#diff-afd285a1775e85740e391e9f1d84881e0161a593318e1f398ff58f13da6866d8R1-R22): Added the `complementValidationError` function to append detailed descriptions to validation errors when the `value` is undefined.
* [`packages/core/src/factory/events.ts`](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78R25-R26): Imported and used the `complementValidationError` function in the `createValidateEvent` function to enhance error handling during event creation. [[1]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78R25-R26) [[2]](diffhunk://#diff-3b6bba958553d7f7e9e574a08fc1edab4c3fb4f8fbc49136bf2649f4b11f0d78R140)

### Dependency upgrades:
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL40-R44): Upgraded `@samchon/openapi` from version `4.4.1` to `4.5.0` and `typia` from version `9.4.0` to `9.5.0` across multiple entries to ensure compatibility and leverage new features. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL40-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2579-R2580) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16640-R16641)
* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL23-R24): Updated the `@samchon/openapi` and `typia` version specifications in the `typia` catalog to match the new versions.