### PR TITLE
fix(core): ensure executor description is not null before calling decribe

### DIFF
--- a/packages/core/src/MicroAgentica.ts
+++ b/packages/core/src/MicroAgentica.ts
@@ -166,7 +166,7 @@ export class MicroAgentica<Model extends ILlmSchema.Model> {
       ctx,
       this.operations_.array,
     );
-    if (executes.length) {
+    if (executes.length && this.props.config?.executor?.describe !== null) {
       await describe(ctx, executes);
     }
 


### PR DESCRIPTION
This pull request introduces a conditional check to ensure that the `describe` method is only executed when the `executor.describe` property in the configuration is not `null`. This change enhances the robustness of the `MicroAgentica` class by preventing unnecessary or invalid calls to the `describe` function.

* [`packages/core/src/MicroAgentica.ts`](diffhunk://#diff-d0b41ca18164569e2f6b061dcac423715cca7eaa85200c4c1ed410f179850b28L169-R169): Updated the conditional in the `if` statement to include a check for `this.props.config?.executor?.describe !== null` before calling the `describe` function.