### PR TITLE
feat(core): make file uploader exactly

### DIFF
--- a/packages/core/src/factory/histories.ts
+++ b/packages/core/src/factory/histories.ts
@@ -147,7 +147,7 @@ export function decodeUserMessageContent(content: AgenticaUserMessageContent): O
   if (content.type === "file") {
     return {
       type: "file",
-      file: content.file.type === "data"
+      file: content.file.type === "base64"
         ? {
             file_data: content.file.data,
             filename: content.file.name,
@@ -162,7 +162,9 @@ export function decodeUserMessageContent(content: AgenticaUserMessageContent): O
     return {
       type: "image_url",
       image_url: {
-        url: content.url,
+        url: content.image.type === "base64"
+          ? content.image.data
+          : content.image.url,
         detail: content.detail,
       },
     };

--- a/packages/core/src/histories/contents/AgenticaUserMessageFileContent.ts
+++ b/packages/core/src/histories/contents/AgenticaUserMessageFileContent.ts
@@ -8,19 +8,17 @@ import type { AgenticaUserMessageContentBase } from "./AgenticaUserMessageConten
  */
 export interface AgenticaUserMessageFileContent extends AgenticaUserMessageContentBase<"file"> {
   /**
-   * Reference to the pre-uploaded file or the data itself.
-   *
-   * @todo Properly define independent interface
+   * Reference to the pre-uploaded file or the base64 data itself.
    */
-  file: AgenticaUserMessageFileContent.IReference | AgenticaUserMessageFileContent.IData;
+  file: AgenticaUserMessageFileContent.IId | AgenticaUserMessageFileContent.IBase64;
 }
 export namespace AgenticaUserMessageFileContent {
-  export interface IReference {
-    type: "reference";
+  export interface IId {
+    type: "id";
     id: string;
   }
-  export interface IData {
-    type: "data";
+  export interface IBase64 {
+    type: "base64";
     name: string;
     data: string;
   }

--- a/packages/core/src/histories/contents/AgenticaUserMessageImageContent.ts
+++ b/packages/core/src/histories/contents/AgenticaUserMessageImageContent.ts
@@ -10,9 +10,9 @@ import type { AgenticaUserMessageContentBase } from "./AgenticaUserMessageConten
  */
 export interface AgenticaUserMessageImageContent extends AgenticaUserMessageContentBase<"image"> {
   /**
-   * Image URL.
+   * Image URL or base64 data itself.
    */
-  url: string & tags.Format<"url">;
+  image: AgenticaUserMessageImageContent.IUrl | AgenticaUserMessageImageContent.IBase64;
 
   /**
    * Specifies the detail level of the image.
@@ -20,4 +20,14 @@ export interface AgenticaUserMessageImageContent extends AgenticaUserMessageCont
    * @reference https://platform.openai.com/docs/guides/vision#low-or-high-fidelity-image-understanding
    */
   detail?: "auto" | "high" | "low" | undefined;
+}
+export namespace AgenticaUserMessageImageContent {
+  export interface IUrl {
+    type: "url";
+    url: string & tags.Format<"url">;
+  }
+  export interface IBase64 {
+    type: "base64";
+    data: string;
+  }
 }


### PR DESCRIPTION
This pull request updates how file and image message contents are represented and decoded in the codebase. The main goal is to make the handling of files and images more explicit and flexible by distinguishing between references/URLs and base64-encoded data. The changes affect both the type definitions and the decoding logic for user message content.

**File content representation:**

* Changed `AgenticaUserMessageFileContent.file` to be either an `IId` (with `type: "id"`) or an `IBase64` (with `type: "base64"`), replacing the previous `IReference` and `IData` types.
* Updated the decoding logic in `decodeUserMessageContent` to handle the new `type: "base64"` for files instead of the previous `type: "data"`.

**Image content representation:**

* Changed `AgenticaUserMessageImageContent.url` to `image`, which can be either an `IUrl` (with `type: "url"`) or an `IBase64` (with `type: "base64"`), allowing images to be provided as URLs or base64 data. [[1]](diffhunk://#diff-e9fba8132a0a963095c7a163a97041f1226504bf617bea23edf10e905c633a30L13-R15) [[2]](diffhunk://#diff-e9fba8132a0a963095c7a163a97041f1226504bf617bea23edf10e905c633a30R24-R33)
* Updated the decoding logic in `decodeUserMessageContent` to support the new `image` structure, using base64 data when `type: "base64"` and URL otherwise.