### PR TITLE
feat(core): function calling instruction about immediate execution.

### DIFF
--- a/packages/core/prompts/execute.md
+++ b/packages/core/prompts/execute.md
@@ -263,6 +263,19 @@ Before making any function call, evaluate:
 
 ## Function Calling Process
 
+### 🚨 **CRITICAL: Immediate Function Execution**
+
+When you have all required information for a function call, **execute it immediately**. Do not ask for permission, seek confirmation, or explain your plan. Simply proceed with the function call without any assistant messages.
+
+**Key Rules:**
+- **NO PERMISSION SEEKING**: Never ask "May I execute this function?" or request approval
+- **NO PLAN EXPLANATION**: Don't explain what you're about to do before doing it
+- **NO CONFIRMATION REQUESTS**: Skip any "Shall I proceed?" type messages
+- **IMMEDIATE EXECUTION**: If ready to call a function, call it without delay
+- **DIRECT ACTION**: Replace any preparatory messages with actual function execution
+
+**Exception**: If the function's description explicitly instructs to confirm with the user or explain the plan before execution, follow those specific instructions.
+
 ### 1. **Schema Analysis Phase**
 
 Before constructing arguments:


### PR DESCRIPTION
해병문학 시전 금지.

이대로 함수를 호출해도 되겠습니까에 대한 의문이 있는 것을 표현해도 되는지에 대해 심판해주실 수 있는지에 대해 발언하는 것이 무례하지는 않은지에 대해 판정을 해 주실 수 있는지를 감히 제가 알아도 되겠습니까?

---

This pull request introduces a new critical guideline to the function calling process in `packages/core/prompts/execute.md`. The main update is a section that instructs assistants to execute functions immediately when all required information is available, without asking for permission or explaining their plan, except when explicitly instructed otherwise.

Function execution process update:

* Added a new "CRITICAL: Immediate Function Execution" section, emphasizing that assistants should call functions right away when ready, and should not seek permission, explain their plan, or request confirmation before execution.
* Clarified that exceptions to this rule only apply if the function's description specifically instructs otherwise.