### PR TITLE
fix(core): remove unnecessary content length check for assistant messages

### DIFF
--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -119,7 +119,6 @@ export async function call<Model extends ILlmSchema.Model>(
     if (
       choice.message.role === "assistant"
       && choice.message.content != null
-      && choice.message.content.length !== 0
     ) {
       const text: string = choice.message.content;
       const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent({

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -230,7 +230,6 @@ async function step<Model extends ILlmSchema.Model>(
     if (
       choice.message.role === "assistant"
       && choice.message.content != null
-      && choice.message.content.length !== 0
     ) {
       const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent({
         stream: toAsyncGenerator(choice.message.content),


### PR DESCRIPTION
This pull request makes a small change to the logic for handling assistant messages in the orchestration flow. The check for empty message content has been removed, allowing messages with empty content to be processed as long as the content is not `null`.

* Removed the `choice.message.content.length !== 0` check in both `call.ts` and `select.ts`, so assistant messages with empty (but non-null) content will now be processed. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL122) [[2]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL233)