### PR TITLE
feat(core): refactor call and select functions to utilize MPSC for streaming context management

### DIFF
--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -24,9 +24,10 @@ import { isAgenticaContext } from "../context/internal/isAgenticaContext";
 import { createAssistantMessageEvent, createCallEvent, createExecuteEvent, createJsonParseErrorEvent, createValidateEvent } from "../factory/events";
 import { decodeHistory, decodeUserMessageContent } from "../factory/histories";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
-import { StreamUtil, toAsyncGenerator } from "../utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "../utils/StreamUtil";
 
 import { cancelFunctionFromContext } from "./internal/cancelFunctionFromContext";
+import { MPSC } from "../utils";
 
 export async function call<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model> | MicroAgenticaContext<Model>,
@@ -85,8 +86,68 @@ export async function call<Model extends ILlmSchema.Model>(
     tool_choice: "auto",
     // parallel_tool_calls: false,
   });
-  const chunks: OpenAI.ChatCompletionChunk[] = await StreamUtil.readAll(stream);
-  const completion: OpenAI.ChatCompletion = ChatGptCompletionMessageUtil.merge(chunks);
+  
+
+  const selectContext: ({
+    content: string;
+    mpsc: MPSC<string>;
+  })[] = [];
+  const nullableCompletion = await StreamUtil.reduce<OpenAI.ChatCompletionChunk, Promise<OpenAI.ChatCompletion>>(stream, async (accPromise, chunk) => {
+    const acc = await accPromise;
+
+    const registerContext = (
+      choices: OpenAI.ChatCompletionChunk.Choice[],
+    ) => {
+      for (const choice of choices) {
+        /**
+         * @TODO fix it
+         * Sometimes, the complete message arrives along with a finish reason.
+         */
+        if (choice.finish_reason != null) {
+          selectContext[choice.index]?.mpsc.close();
+          continue;
+        }
+
+        if (choice.delta.content == null) {
+          continue;
+        }
+
+        if (selectContext[choice.index] != null) {
+          selectContext[choice.index]!.content += choice.delta.content;
+          selectContext[choice.index]!.mpsc.produce(choice.delta.content);
+          continue;
+        }
+
+        const mpsc = new MPSC<string>();
+
+        selectContext[choice.index] = {
+          content: choice.delta.content,
+          mpsc,
+        };
+        mpsc.produce(choice.delta.content);
+
+        const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent({
+          stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
+          done: () => mpsc.done(),
+          get: () => selectContext[choice.index]?.content ?? "",
+          join: async () => {
+            await mpsc.waitClosed();
+            return selectContext[choice.index]!.content;
+          },
+        });
+        ctx.dispatch(event);
+      }
+    };
+    if (acc.object === "chat.completion.chunk") {
+      registerContext([acc, chunk].flatMap(v => v.choices));
+      return ChatGptCompletionMessageUtil.merge([acc, chunk]);
+    }
+    registerContext(chunk.choices);
+    return ChatGptCompletionMessageUtil.accumulate(acc, chunk);
+  });
+  const completion = nullableCompletion!;
+  
+
   const executes: AgenticaExecuteEvent<Model>[] = [];
 
   const retry: number = ctx.config?.retry ?? AgenticaConstant.RETRY;
@@ -115,19 +176,6 @@ export async function call<Model extends ILlmSchema.Model>(
           });
         }
       }
-    }
-    if (
-      choice.message.role === "assistant"
-      && choice.message.content != null
-    ) {
-      const text: string = choice.message.content;
-      const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent({
-        get: () => text,
-        done: () => true,
-        stream: toAsyncGenerator(text),
-        join: async () => Promise.resolve(text),
-      });
-      ctx.dispatch(event);
     }
   }
   return executes;

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -18,9 +18,10 @@ import { AgenticaSystemPrompt } from "../constants/AgenticaSystemPrompt";
 import { createAssistantMessageEvent } from "../factory/events";
 import { decodeHistory, decodeUserMessageContent } from "../factory/histories";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
-import { StreamUtil, toAsyncGenerator } from "../utils/StreamUtil";
+import { streamDefaultReaderToAsyncGenerator, StreamUtil } from "../utils/StreamUtil";
 
 import { selectFunctionFromContext } from "./internal/selectFunctionFromContext";
+import { MPSC } from "../utils";
 
 const CONTAINER: ILlmApplication<"chatgpt"> = typia.llm.application<
   __IChatSelectFunctionsApplication,
@@ -169,9 +170,65 @@ async function step<Model extends ILlmSchema.Model>(
     // parallel_tool_calls: false,
   });
 
-  const chunks = await StreamUtil.readAll(completionStream);
-  const completion = ChatGptCompletionMessageUtil.merge(chunks);
+  const selectContext: ({
+    content: string;
+    mpsc: MPSC<string>;
+  })[] = [];
+  const nullableCompletion = await StreamUtil.reduce<OpenAI.ChatCompletionChunk, Promise<OpenAI.ChatCompletion>>(completionStream, async (accPromise, chunk) => {
+    const acc = await accPromise;
 
+    const registerContext = (
+      choices: OpenAI.ChatCompletionChunk.Choice[],
+    ) => {
+      for (const choice of choices) {
+        /**
+         * @TODO fix it
+         * Sometimes, the complete message arrives along with a finish reason.
+         */
+        if (choice.finish_reason != null) {
+          selectContext[choice.index]?.mpsc.close();
+          continue;
+        }
+
+        if (choice.delta.content == null) {
+          continue;
+        }
+
+        if (selectContext[choice.index] != null) {
+          selectContext[choice.index]!.content += choice.delta.content;
+          selectContext[choice.index]!.mpsc.produce(choice.delta.content);
+          continue;
+        }
+
+        const mpsc = new MPSC<string>();
+
+        selectContext[choice.index] = {
+          content: choice.delta.content,
+          mpsc,
+        };
+        mpsc.produce(choice.delta.content);
+
+        const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent({
+          stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
+          done: () => mpsc.done(),
+          get: () => selectContext[choice.index]?.content ?? "",
+          join: async () => {
+            await mpsc.waitClosed();
+            return selectContext[choice.index]!.content;
+          },
+        });
+        ctx.dispatch(event);
+      }
+    };
+    if (acc.object === "chat.completion.chunk") {
+      registerContext([acc, chunk].flatMap(v => v.choices));
+      return ChatGptCompletionMessageUtil.merge([acc, chunk]);
+    }
+    registerContext(chunk.choices);
+    return ChatGptCompletionMessageUtil.accumulate(acc, chunk);
+  });
+  const completion = nullableCompletion!;
+  
   // ----
   // VALIDATION
   // ----
@@ -224,20 +281,6 @@ async function step<Model extends ILlmSchema.Model>(
           selectFunctionFromContext(ctx, reference);
         }
       }
-    }
-
-    // ASSISTANT MESSAGE
-    if (
-      choice.message.role === "assistant"
-      && choice.message.content != null
-    ) {
-      const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent({
-        stream: toAsyncGenerator(choice.message.content),
-        join: async () => Promise.resolve(choice.message.content!),
-        done: () => true,
-        get: () => choice.message.content!,
-      });
-      ctx.dispatch(event);
     }
   }
 }

--- a/test/src/features/rpc/test_rpc_websocket_call.ts
+++ b/test/src/features/rpc/test_rpc_websocket_call.ts
@@ -80,9 +80,6 @@ export async function test_rpc_websocket_call(): Promise<void | false> {
     execute: async (evt) => {
       events.push(evt);
     },
-    cancel: async (evt) => {
-      events.push(evt);
-    },
   });
   await connector.connect(`ws://localhost:${port}`);
 
@@ -99,7 +96,7 @@ export async function test_rpc_websocket_call(): Promise<void | false> {
   await server.close();
 
   TestValidator.equals("events")(
-    events.filter(e => e.type !== "cancel").map(e => e.type),
+    events.map(e => e.type),
   )([
     "initialize",
     "assistantMessage",

--- a/test/src/features/rpc/test_rpc_websocket_initialize.ts
+++ b/test/src/features/rpc/test_rpc_websocket_initialize.ts
@@ -76,15 +76,10 @@ export async function test_rpc_websocket_initialize(): Promise<void | false> {
 
   TestValidator.equals("events")([
     {
-      type: "text",
-      role: "user",
-    },
-    {
       type: "initialize",
     },
     {
-      type: "text",
-      role: "assistant",
+      type: "assistantMessage",
     },
   ])(events);
 }

--- a/test/src/features/test_base_event.ts
+++ b/test/src/features/test_base_event.ts
@@ -29,7 +29,7 @@ export async function test_base_event(): Promise<void | false> {
   const initializeListener = () => {
     initializeCount++;
   };
-  const textListener = () => {
+  const textListener = async () => {
     textCount++;
   };
 
@@ -46,10 +46,10 @@ export async function test_base_event(): Promise<void | false> {
     );
   }
 
-  // total twice: initialize, select
-  if (textCount !== 2) {
+  // total once
+  if (textCount !== 1) {
     throw new Error(
-      `Text event should be called twice, but called ${textCount} times`,
+      `Text event should be called once, but called ${textCount} times`,
     );
   }
 
@@ -66,9 +66,9 @@ export async function test_base_event(): Promise<void | false> {
     );
   }
 
-  // total twice: (initialize, select) * 2
-  if ((textCount as number) !== 4) {
-    throw new Error(`Text count should be 4, but got ${textCount}`);
+  // total twice
+  if ((textCount as number) !== 2) {
+    throw new Error(`Text count should be 2, but got ${textCount}`);
   }
 
   // remove text event listener
@@ -83,7 +83,7 @@ export async function test_base_event(): Promise<void | false> {
       `Initialize count should remain 1, but got ${initializeCount}`,
     );
   }
-  if ((textCount as number) !== 4) {
-    throw new Error(`Text count should remain 4, but got ${textCount}`);
+  if ((textCount as number) !== 2) {
+    throw new Error(`Text count should remain 2, but got ${textCount}`);
   }
 }

--- a/test/src/features/test_base_work.ts
+++ b/test/src/features/test_base_work.ts
@@ -22,7 +22,14 @@ export async function test_base_work(): Promise<void | false> {
   });
   const result: AgenticaHistory<"chatgpt">[]
     = await agent.conversate("What your role?");
-  if (result[0]?.type !== "assistantMessage" || result[0]?.text !== "What your role?") {
-    throw new Error("Result is not equal to prompt histories");
+  if(
+    result[0]?.type === "userMessage"
+    && result[0].contents.length === 1
+    && result[0].contents[0]?.type === "text"
+    && result[0].contents[0].text === "What your role?"
+  ) {
+    return;
   }
+
+  throw new Error("Result is not equal to prompt histories");
 }

--- a/test/src/features/test_call_streaming_base.ts
+++ b/test/src/features/test_call_streaming_base.ts
@@ -1,0 +1,63 @@
+import { Agentica, AgenticaAssistantMessageEvent, IAgenticaController } from "@agentica/core";
+import { TestGlobal } from "../TestGlobal";
+import OpenAI from "openai";
+import typia from "typia";
+import assert from "node:assert";
+
+class Weather {
+  public getWeather(props: {
+    /**
+     * City to get weather
+     */
+    city: string;
+  }): string {
+    return `The weather in ${props.city} is sunny`;
+  }
+}
+
+export async function test_call_streaming_base(): Promise<void | false> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+
+  const controller: IAgenticaController<"chatgpt"> = {
+    protocol: "class",
+    name: "weather",
+    application: typia.llm.application<Weather, "chatgpt">(),
+    execute: new Weather(),
+  };
+  const agent = new Agentica({
+    model: "chatgpt",
+    vendor: {
+      model: "gpt-4o-mini",
+      api: new OpenAI({
+        apiKey: TestGlobal.chatgptApiKey,
+      }),
+    },
+    controllers: [controller],
+    config: {
+      executor: {
+        initialize: null,
+        describe: null,
+      },
+    }
+  });
+
+
+  let isAssistantMessageStreaming = false;
+  agent.on("assistantMessage", async (event: AgenticaAssistantMessageEvent) => {
+    let count = 0;
+    for await (const _ of event.stream) {
+      count++;
+    }
+    isAssistantMessageStreaming = count > 2;
+  });
+
+  
+  const result = await agent.conversate("How are the weather?");
+  assert(result.length === 3);
+  assert(result[0]?.type === "userMessage");
+  assert(result[1]?.type === "select");
+  assert(result[2]?.type === "assistantMessage");
+  assert(isAssistantMessageStreaming);
+}

--- a/test/src/features/test_select_streaming_base.ts
+++ b/test/src/features/test_select_streaming_base.ts
@@ -1,0 +1,60 @@
+import { Agentica, AgenticaAssistantMessageEvent, IAgenticaController } from "@agentica/core";
+import { TestGlobal } from "../TestGlobal";
+import OpenAI from "openai";
+import typia from "typia";
+import assert from "node:assert";
+
+class Weather {
+  public getWeather(props: {
+    /**
+     * City to get weather
+     */
+    city: string;
+  }): string {
+    return `The weather in ${props.city} is sunny`;
+  }
+}
+
+export async function test_select_streaming_base(): Promise<void | false> {
+  if (TestGlobal.chatgptApiKey.length === 0) {
+    return false;
+  }
+
+  const controller: IAgenticaController<"chatgpt"> = {
+    protocol: "class",
+    name: "weather",
+    application: typia.llm.application<Weather, "chatgpt">(),
+    execute: new Weather(),
+  };
+  const agent = new Agentica({
+    model: "chatgpt",
+    vendor: {
+      model: "gpt-4o-mini",
+      api: new OpenAI({
+        apiKey: TestGlobal.chatgptApiKey,
+      }),
+    },
+    controllers: [controller],
+    config: {
+      executor: {
+        initialize: null,
+        describe: null,
+      },
+    }
+  });
+
+  let isAssistantMessageStreaming = false;
+  agent.on("assistantMessage", async (event: AgenticaAssistantMessageEvent) => {
+    let count = 0;
+    for await (const _ of event.stream) {
+      count++;
+    }
+    isAssistantMessageStreaming = count > 2;
+  });
+
+  const result = await agent.conversate("Please create the BBS article with the title 'Hello, world!' and the content 'This is a test article.'");
+  assert(result.length === 2);
+  assert(result[0]?.type === "userMessage");
+  assert(result[1]?.type === "assistantMessage");
+  assert(isAssistantMessageStreaming);
+}


### PR DESCRIPTION
This pull request refactors how assistant message events are handled during streaming completions in both the `call` and `select` orchestration flows. It introduces a more robust mechanism for managing partial message content and streaming updates using a multi-producer, single-consumer (MPSC) queue. The assistant message event dispatch logic is now unified and incremental, leading to more accurate event handling and improved test coverage. Several related tests have been updated to reflect these changes.

**Streaming and Assistant Message Handling Improvements:**

* Replaced previous chunk aggregation and event dispatch logic in `call.ts` and `select.ts` with a new streaming approach using `MPSC`, enabling incremental assistant message events as content arrives. This ensures events are dispatched correctly for each partial message and closes streams on completion. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL27-R30) [[2]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL88-R150) [[3]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL119-L131) [[4]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL21-R24) [[5]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL172-R230) [[6]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL228-L241)

**Test Suite Updates:**

* Updated `test_base_event.ts` to expect the new event counts and asynchronous event handlers, reflecting the revised assistant message event dispatch logic. [[1]](diffhunk://#diff-27e7e5427e3d38845c4723647369987ddb20c284789d28e25424d00ba3af4df1L32-R32) [[2]](diffhunk://#diff-27e7e5427e3d38845c4723647369987ddb20c284789d28e25424d00ba3af4df1L49-R52) [[3]](diffhunk://#diff-27e7e5427e3d38845c4723647369987ddb20c284789d28e25424d00ba3af4df1L69-R71) [[4]](diffhunk://#diff-27e7e5427e3d38845c4723647369987ddb20c284789d28e25424d00ba3af4df1L86-R87)
* Updated `test_base_work.ts` to check for the new structure of user message events in result histories.
* Updated `test_rpc_websocket_call.ts` and `test_rpc_websocket_initialize.ts` to expect the new event types and order, removing legacy "cancel" and "text" event expectations in favor of "assistantMessage". [[1]](diffhunk://#diff-76d9a40cf186198718fadc82443296eef1dfefe6d222483ea6aeb559e883f018L83-L85) [[2]](diffhunk://#diff-76d9a40cf186198718fadc82443296eef1dfefe6d222483ea6aeb559e883f018L102-R99) [[3]](diffhunk://#diff-f8908b541db756f437b57eb09f7a4caac77443a7b22961294bbf9bd79a5a86f2L78-R82)