### PR TITLE
feat(core): add reasoning support in ChatCompletionMessage for open router

### DIFF
--- a/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
+++ b/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
@@ -54,6 +54,10 @@ function accumulate(origin: ChatCompletion, chunk: ChatCompletionChunk): ChatCom
         content: choice.delta.content ?? null,
         refusal: choice.delta.refusal ?? null,
         role: "assistant",
+        ...({
+          // for open router
+          reasoning: (choice.delta as { reasoning?: string }).reasoning ?? null,
+        })
       } satisfies ChatCompletionMessage,
     };
   });
@@ -130,6 +134,16 @@ function mergeChoice(acc: ChatCompletion.Choice, cur: ChatCompletionChunk.Choice
     }
     else {
       acc.message.refusal += cur.delta.refusal;
+    }
+  }
+
+  // for open router
+  if ((cur.delta as { reasoning?: string }).reasoning != null) {
+    if ((acc.message as { reasoning?: string }).reasoning == null) {
+      (acc.message as { reasoning?: string }).reasoning = (cur.delta as { reasoning?: string }).reasoning;
+    }
+    else {
+      (acc.message as unknown as { reasoning: string }).reasoning += (cur.delta as { reasoning: string }).reasoning;
     }
   }
 


### PR DESCRIPTION
This pull request updates the chat completion message utilities to support the `reasoning` field, which is used by the OpenRouter API. The changes ensure that the `reasoning` property is properly accumulated and merged when processing chat completion chunks.

**OpenRouter compatibility:**

* Added support for the `reasoning` property in the accumulated chat completion message within the `accumulate` function, ensuring that any reasoning provided by the model is captured.
* Updated the `mergeChoice` function to correctly merge the `reasoning` field from chat completion chunks, concatenating reasoning strings when necessary.