### PR TITLE
Fix typo in client application requirements

### DIFF
--- a/website/content/docs/setup/manual.mdx
+++ b/website/content/docs/setup/manual.mdx
@@ -114,7 +114,7 @@ And then setup `nestia` with `npx nestia setup` command. It will setup every req
 npm install @agentica/rpc tgrid
 ```
 
-Client application does noot require many packages.
+Client application does not require many packages.
 
 Just install `@agentica/rpc` and [`tgrid`](https://tgrid.com) packages.
 


### PR DESCRIPTION
Fix `noot` to `not` in client application setup manual documentation