### PR TITLE
feat(core): retry only one time for `openrouter`

### DIFF
--- a/packages/core/eslint.config.mts
+++ b/packages/core/eslint.config.mts
@@ -15,5 +15,6 @@ export default wrtnlabs({
     "ts/no-unsafe-assignment": "off",
     "ts/no-unsafe-call": "off",
     "ts/no-unsafe-return": "off",
+    "eslint-comments/no-unlimited-disable": "off",
   },
 });

--- a/packages/core/src/events/AgenticaJsonParseErrorEvent.ts
+++ b/packages/core/src/events/AgenticaJsonParseErrorEvent.ts
@@ -9,4 +9,5 @@ export interface AgenticaJsonParseErrorEvent<Model extends ILlmSchema.Model>
   operation: AgenticaOperation<Model>;
   arguments: string;
   errorMessage: string;
+  life: number;
 }

--- a/packages/core/src/events/AgenticaValidateEvent.ts
+++ b/packages/core/src/events/AgenticaValidateEvent.ts
@@ -29,5 +29,7 @@ export interface AgenticaValidateEvent<
    */
   result: IValidation.IFailure;
 
+  life: number;
+
   toJSON: () => IAgenticaEventJson.IValidate;
 }

--- a/packages/core/src/factory/events.ts
+++ b/packages/core/src/factory/events.ts
@@ -118,6 +118,7 @@ export function createJsonParseErrorEvent<Model extends ILlmSchema.Model>(props:
   operation: AgenticaOperation<Model>;
   arguments: string;
   errorMessage: string;
+  life: number;
 }): AgenticaJsonParseErrorEvent<Model> {
   const created_at: string = new Date().toISOString();
   return {
@@ -127,6 +128,7 @@ export function createJsonParseErrorEvent<Model extends ILlmSchema.Model>(props:
     operation: props.operation,
     arguments: props.arguments,
     errorMessage: props.errorMessage,
+    life: props.life,
   };
 }
 
@@ -134,6 +136,7 @@ export function createValidateEvent<Model extends ILlmSchema.Model>(props: {
   id: string;
   operation: AgenticaOperation<Model>;
   result: IValidation.IFailure;
+  life: number;
 }): AgenticaValidateEvent<Model> {
   const created_at: string = new Date().toISOString();
   return {
@@ -142,12 +145,14 @@ export function createValidateEvent<Model extends ILlmSchema.Model>(props: {
     created_at,
     operation: props.operation,
     result: props.result,
+    life: props.life,
     toJSON: () => ({
       type: "validate",
       id: props.id,
       created_at,
       operation: props.operation.toJSON(),
       result: props.result,
+      life: props.life,
     }),
   };
 }

--- a/packages/core/src/json/IAgenticaEventJson.ts
+++ b/packages/core/src/json/IAgenticaEventJson.ts
@@ -119,6 +119,8 @@ export namespace IAgenticaEventJson {
      * Validation result as a failure.
      */
     result: IValidation.IFailure;
+
+    life: number;
   }
 
   export interface IJsonParseError extends IBase<"jsonParseError"> {
@@ -138,6 +140,8 @@ export namespace IAgenticaEventJson {
      * Error message of the JSON parse error.
      */
     errorMessage: string;
+
+    life: number;
   }
 
   /**

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -35,7 +35,7 @@ export async function call<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model> | MicroAgenticaContext<Model>,
   operations: AgenticaOperation<Model>[],
 ): Promise<AgenticaExecuteEvent<Model>[]> {
-  const _retryFn = __get_retry(ctx.config?.retry ?? AgenticaConstant.RETRY);
+  const _retryFn = __get_retry(1);
   const retryFn = async (fn: (prevError?: unknown) => Promise<OpenAI.ChatCompletion>) => {
     return _retryFn(fn).catch((e) => {
       if (e instanceof AssistantMessageEmptyError) {
@@ -111,7 +111,7 @@ export async function call<Model extends ILlmSchema.Model>(
     const completion = await reduceStreamingWithDispatch(stream, (props) => {
       const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent(props);
       void ctx.dispatch(event).catch(() => {});
-      ctx.abortSignal
+      ctx.abortSignal;
     });
 
     const allAssistantMessagesEmpty = completion.choices.every(v => v.message.tool_calls == null && v.message.content === "");

--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -111,7 +111,6 @@ export async function call<Model extends ILlmSchema.Model>(
     const completion = await reduceStreamingWithDispatch(stream, (props) => {
       const event: AgenticaAssistantMessageEvent = createAssistantMessageEvent(props);
       void ctx.dispatch(event).catch(() => {});
-      ctx.abortSignal;
     });
 
     const allAssistantMessagesEmpty = completion.choices.every(v => v.message.tool_calls == null && v.message.content === "");
@@ -183,6 +182,7 @@ async function predicate<Model extends ILlmSchema.Model>(
     = parseArguments(
       operation,
       toolCall,
+      life,
     );
   await ctx.dispatch(call);
   if (call.type === "jsonParseError") {
@@ -196,6 +196,7 @@ async function predicate<Model extends ILlmSchema.Model>(
       id: toolCall.id,
       operation,
       result: check,
+      life,
     });
     await ctx.dispatch(event);
     return correctTypeError(
@@ -293,6 +294,7 @@ async function correctJsonError<Model extends ILlmSchema.Model>(
 function parseArguments<Model extends ILlmSchema.Model>(
   operation: AgenticaOperation<Model>,
   toolCall: OpenAI.ChatCompletionMessageToolCall,
+  life: number,
 ): AgenticaCallEvent<Model> | AgenticaJsonParseErrorEvent<Model> {
   try {
     const data: Record<string, unknown> = JSON.parse(toolCall.function.arguments);
@@ -308,6 +310,7 @@ function parseArguments<Model extends ILlmSchema.Model>(
       operation,
       arguments: toolCall.function.arguments,
       errorMessage: error instanceof Error ? error.message : String(error),
+      life,
     });
   }
 }

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -95,7 +95,7 @@ async function step<Model extends ILlmSchema.Model>(
   retry: number,
   failures?: IFailure[],
 ): Promise<void> {
-  const _retryFn = __get_retry(ctx.config?.retry ?? AgenticaConstant.RETRY);
+  const _retryFn = __get_retry(1);
   const retryFn = async (fn: (prevError?: unknown) => Promise<OpenAI.ChatCompletion>) => {
     return _retryFn(fn).catch((e) => {
       if (e instanceof AssistantMessageEmptyError) {

--- a/packages/core/src/utils/AssistantMessageEmptyError.ts
+++ b/packages/core/src/utils/AssistantMessageEmptyError.ts
@@ -1,6 +1,13 @@
 export class AssistantMessageEmptyError extends Error {
   constructor() {
     super();
+    const proto = new.target.prototype;
+    // eslint-disable-next-line
+    if (Object.setPrototypeOf) { Object.setPrototypeOf(this, proto); }
+    else {
+      // eslint-disable-next-line
+      (this as any).__proto__ = proto; 
+    }
   }
 }
 


### PR DESCRIPTION
This pull request makes minor changes to the retry logic in the orchestration functions, ensuring that all retries are now hardcoded to a single attempt rather than using the configurable value. Additionally, there is a small formatting fix in one of the function bodies.

Retry logic changes:

* In both the `call` function (`packages/core/src/orchestrate/call.ts`) and the `step` function (`packages/core/src/orchestrate/select.ts`), the retry count is now hardcoded to `1` instead of using `ctx.config?.retry` or a constant, simplifying the retry behavior. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL38-R38) [[2]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL98-R98)

Code formatting:

* Added a missing semicolon after `ctx.abortSignal` in the `call` function for consistency and clarity.