### PR TITLE
fix(core): special `JSON.parse` rule for OpenRouter

### DIFF
--- a/packages/core/src/orchestrate/call.ts
+++ b/packages/core/src/orchestrate/call.ts
@@ -27,6 +27,7 @@ import { __get_retry } from "../utils/__retry";
 import { AssistantMessageEmptyError, AssistantMessageEmptyWithReasoningError } from "../utils/AssistantMessageEmptyError";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
 import { reduceStreamingWithDispatch } from "../utils/ChatGptCompletionStreamingUtil";
+import { JsonUtil } from "../utils/JsonUtil";
 import { StreamUtil, toAsyncGenerator } from "../utils/StreamUtil";
 
 import { cancelFunctionFromContext } from "./internal/cancelFunctionFromContext";
@@ -297,7 +298,7 @@ function parseArguments<Model extends ILlmSchema.Model>(
   life: number,
 ): AgenticaCallEvent<Model> | AgenticaJsonParseErrorEvent<Model> {
   try {
-    const data: Record<string, unknown> = JSON.parse(toolCall.function.arguments);
+    const data: Record<string, unknown> = JsonUtil.parse(toolCall.function.arguments);
     return createCallEvent({
       id: toolCall.id,
       operation,

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -17,6 +17,7 @@ import { AgenticaDefaultPrompt } from "../constants/AgenticaDefaultPrompt";
 import { AgenticaSystemPrompt } from "../constants/AgenticaSystemPrompt";
 import { decodeHistory, decodeUserMessageContent } from "../factory/histories";
 import { ChatGptCompletionMessageUtil } from "../utils/ChatGptCompletionMessageUtil";
+import { JsonUtil } from "../utils/JsonUtil";
 import { StreamUtil } from "../utils/StreamUtil";
 
 import { cancelFunctionFromContext } from "./internal/cancelFunctionFromContext";
@@ -185,7 +186,7 @@ async function step<Model extends ILlmSchema.Model>(
           continue;
         }
 
-        const input: object = JSON.parse(tc.function.arguments) as object;
+        const input: object = JsonUtil.parse(tc.function.arguments) as object;
         const validation: IValidation<__IChatFunctionReference.IProps>
           = typia.validate<__IChatFunctionReference.IProps>(input);
         if (validation.success === false) {

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -20,6 +20,7 @@ import { decodeHistory, decodeUserMessageContent } from "../factory/histories";
 import { __get_retry } from "../utils/__retry";
 import { AssistantMessageEmptyError, AssistantMessageEmptyWithReasoningError } from "../utils/AssistantMessageEmptyError";
 import { reduceStreamingWithDispatch } from "../utils/ChatGptCompletionStreamingUtil";
+import { JsonUtil } from "../utils/JsonUtil";
 import { toAsyncGenerator } from "../utils/StreamUtil";
 
 import { selectFunctionFromContext } from "./internal/selectFunctionFromContext";
@@ -228,7 +229,7 @@ async function step<Model extends ILlmSchema.Model>(
         if (tc.function.name !== "selectFunctions") {
           continue;
         }
-        const input: object = JSON.parse(tc.function.arguments) as object;
+        const input: object = JsonUtil.parse(tc.function.arguments) as object;
         const validation: IValidation<__IChatFunctionReference.IProps>
           = typia.validate<__IChatFunctionReference.IProps>(input);
         if (validation.success === false) {

--- a/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
+++ b/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
@@ -8,11 +8,12 @@ import type {
 // import typia from "typia";
 import { ByteArrayUtil } from "./ByteArrayUtil";
 import { ChatGptTokenUsageAggregator } from "./ChatGptTokenUsageAggregator";
+import { JsonUtil } from "./JsonUtil";
 
 function transformCompletionChunk(source: string | Uint8Array): ChatCompletionChunk {
   const str
       = source instanceof Uint8Array ? ByteArrayUtil.toUtf8(source) : source;
-  const result: ChatCompletionChunk = JSON.parse(str) as ChatCompletionChunk;
+  const result: ChatCompletionChunk = JsonUtil.parse(str) as ChatCompletionChunk;
   // const valid = typia.validate<ChatCompletionChunk>(result);
   // if (valid.success === false) {
   //   console.error("Invalid ChatCompletionChunk", valid.errors);

--- a/packages/core/src/utils/JsonUtil.ts
+++ b/packages/core/src/utils/JsonUtil.ts
@@ -1,0 +1,10 @@
+function parse(str: string) {
+  if (str.startsWith("{}{") === true) {
+    str = str.substring(2);
+  }
+  return JSON.parse(str);
+}
+
+export const JsonUtil = {
+  parse,
+};


### PR DESCRIPTION
This pull request introduces a new utility, `JsonUtil`, to centralize and standardize JSON parsing across the codebase. The main improvement is replacing direct `JSON.parse` calls with `JsonUtil.parse`, which adds a safeguard for a specific malformed string edge case. This change enhances robustness and maintainability, especially when handling tool call arguments and streaming data.

**Core Utility Enhancement:**

* Added new `JsonUtil` in `packages/core/src/utils/JsonUtil.ts` with a custom `parse` method that strips a leading `"{}{"` from strings before parsing, handling a known edge case.

**Codebase Refactoring (JSON Parsing):**

* Replaced all direct `JSON.parse` calls with `JsonUtil.parse` in key orchestrate modules: `call.ts`, `cancel.ts`, and `select.ts`, improving consistency and error handling in tool call argument parsing. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eL300-R301) [[2]](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148L188-R189) [[3]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cL231-R232)
* Updated streaming chunk parsing in `ChatGptCompletionMessageUtil.ts` to use `JsonUtil.parse` for safer deserialization of streamed data.

**Dependency Updates:**

* Imported `JsonUtil` in all affected modules to support the new parsing logic. [[1]](diffhunk://#diff-fab757df7c77323a0efe9872a53054b76585edada69dc8515773aa7b598a023eR30) [[2]](diffhunk://#diff-a2469a545a85656142890c66fc2867323de7a65a8685e7f144a40ca778fa5148R20) [[3]](diffhunk://#diff-d08a1ba455bc31708d65ef9948166f391bad9eff3ebf97d754e428530328734cR23)