### PR TITLE
fix: harden select/cancel orchestration and swagger uploader

### DIFF
--- a/packages/chat/src/examples/uploader/AgenticaChatPlaygroundApplication.tsx
+++ b/packages/chat/src/examples/uploader/AgenticaChatPlaygroundApplication.tsx
@@ -87,6 +87,9 @@ export function AgenticaChatUploaderApplication(props: AgenticaChatUploaderAppli
             },
           },
         ],
+        config: {
+          eliticism: false,
+        }
       });
       props.onSuccess(<AgenticaChatApplication agent={agent} />);
     }

--- a/packages/chat/src/examples/uploader/AgenticaChatPlaygroundApplication.tsx
+++ b/packages/chat/src/examples/uploader/AgenticaChatPlaygroundApplication.tsx
@@ -89,7 +89,7 @@ export function AgenticaChatUploaderApplication(props: AgenticaChatUploaderAppli
         ],
         config: {
           eliticism: false,
-        }
+        },
       });
       props.onSuccess(<AgenticaChatApplication agent={agent} />);
     }

--- a/packages/chat/src/examples/uploader/AgenticaChatUploaderMovie.tsx
+++ b/packages/chat/src/examples/uploader/AgenticaChatUploaderMovie.tsx
@@ -1,4 +1,4 @@
-import type { OpenApi, OpenApiV3, OpenApiV3_1, OpenApiV3_2, SwaggerV2 } from "@typia/interface";
+import type { OpenApi } from "@typia/interface";
 
 import { OpenApiConverter } from "@typia/utils";
 import { load } from "js-yaml";
@@ -6,7 +6,6 @@ import React from "react";
 // eslint-disable-next-line ts/ban-ts-comment
 // @ts-ignore
 import FileUpload from "react-mui-fileuploader";
-import typia from "typia";
 
 interface ExtendedFileProps extends Blob {
   arrayBuffer: () => Promise<ArrayBuffer>;
@@ -28,28 +27,43 @@ export function AgenticaChatUploaderMovie(props: AgenticaChatUploaderMovie.IProp
 
     const buffer: ArrayBuffer = await lastFile.arrayBuffer();
     const content: string = new TextDecoder().decode(buffer);
-    const extension: "json" | "yaml" = lastFile.name.split(".").pop()! as
-      | "json"
-      | "yaml";
+    const isJson: boolean
+      = (lastFile.name.split(".").pop() ?? "").toLowerCase() === "json";
 
+    // PARSE THE RAW FILE (JSON or YAML)
+    let document: unknown;
     try {
-      const document: unknown = extension === "json" ? JSON.parse(content) : load(content);
-      const result = typia.validate<SwaggerV2.IDocument | OpenApiV3.IDocument | OpenApiV3_1.IDocument | OpenApiV3_2.IDocument>(document);
-      if (result.success === false) {
-        props.onChange(null, JSON.stringify(result.errors, null, 2));
-        return;
-      }
-      else {
-        props.onChange(
-          OpenApiConverter.upgradeDocument(result.data),
-          null,
-        );
-      }
+      document = isJson ? JSON.parse(content) : load(content);
     }
     catch {
       props.onChange(
         null,
-        extension === "json" ? "Invalid JSON file" : "Invalid YAML file",
+        isJson ? "Invalid JSON file." : "Invalid YAML file.",
+      );
+      return;
+    }
+
+    // CONVERT TO THE EMENDED OPENAPI DOCUMENT
+    //
+    // Do not run a strict `typia.validate()` here. `OpenApiConverter` (the
+    // very same converter that `Agentica`/`HttpLlm` rely on) only needs the
+    // `swagger`/`openapi` version property, and accepts real-world
+    // specifications leniently. A strict validation would reject lots of
+    // perfectly usable Swagger/OpenAPI documents, blocking the uploader.
+    try {
+      props.onChange(
+        OpenApiConverter.upgradeDocument(
+          document as Parameters<typeof OpenApiConverter.upgradeDocument>[0],
+        ),
+        null,
+      );
+    }
+    catch (error) {
+      props.onChange(
+        null,
+        error instanceof Error
+          ? error.message
+          : "Not a valid Swagger/OpenAPI document.",
       );
       return;
     }

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -1,6 +1,8 @@
+import type { IJsonParseResult } from "@typia/interface";
 import type OpenAI from "openai";
 import type { ILlmFunction, IValidation } from "typia";
 
+import { dedent, LlmJson } from "@typia/utils";
 import typia from "typia";
 
 import type { AgenticaContext } from "../context/AgenticaContext";
@@ -25,11 +27,19 @@ const FUNCTION: ILlmFunction = typia.llm.application<
   __IChatCancelFunctionsApplication
 >().functions[0]!;
 
-interface IFailure {
-  id: string;
-  name: string;
-  validation: IValidation.IFailure;
-}
+type IFailure
+  = | {
+    kind: "parse";
+    id: string;
+    name: string;
+    failure: IJsonParseResult.IFailure;
+  }
+  | {
+    kind: "validation";
+    id: string;
+    name: string;
+    validation: IValidation.IFailure;
+  };
 
 export async function cancel(
   ctx: AgenticaContext,
@@ -185,11 +195,28 @@ async function step(
           continue;
         }
 
-        const input: object = FUNCTION.parse(tc.function.arguments) as object;
+        // LENIENT JSON PARSING
+        //
+        // A malformed JSON string is reported back to the LLM as a parse
+        // failure, mirroring `call.ts`. On success the parsed `.data` (never
+        // the `IJsonParseResult` wrapper itself) is forwarded to validation.
+        const parsed: IJsonParseResult<unknown> = FUNCTION.parse(
+          tc.function.arguments,
+        );
+        if (parsed.success === false) {
+          failures.push({
+            kind: "parse",
+            id: tc.id,
+            name: tc.function.name,
+            failure: parsed,
+          });
+          continue;
+        }
         const validation: IValidation<__IChatFunctionReference.IProps>
-          = FUNCTION.validate(input) as IValidation<__IChatFunctionReference.IProps>;
+          = FUNCTION.validate(parsed.data) as IValidation<__IChatFunctionReference.IProps>;
         if (validation.success === false) {
           failures.push({
+            kind: "validation",
             id: tc.id,
             name: tc.function.name,
             validation,
@@ -217,15 +244,18 @@ async function step(
           continue;
         }
 
-        const input: __IChatFunctionReference.IProps | null
-          = typia.json.isParse<
-            __IChatFunctionReference.IProps
-          >(tc.function.arguments);
-        if (input === null) {
+        // Reuse the lenient parser + validator so that arguments accepted
+        // by the VALIDATION retry above are processed consistently here.
+        const parsed: IJsonParseResult<unknown> = FUNCTION.parse(
+          tc.function.arguments,
+        );
+        const validation: IValidation<__IChatFunctionReference.IProps>
+          = FUNCTION.validate(parsed.data) as IValidation<__IChatFunctionReference.IProps>;
+        if (validation.success === false) {
           continue;
         }
 
-        for (const reference of input.functions) {
+        for (const reference of validation.data.functions) {
           cancelFunctionFromContext(
             ctx,
             reference,
@@ -240,32 +270,60 @@ async function step(
 function emendMessages(failures: IFailure[]): OpenAI.ChatCompletionMessageParam[] {
   return failures
     .map(f => [
-        {
-          role: "assistant",
-          tool_calls: [
-            {
-              type: "function",
-              id: f.id,
-              function: {
-                name: f.name,
-                arguments: JSON.stringify(f.validation.data),
-              },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            type: "function",
+            id: f.id,
+            function: {
+              name: f.name,
+              arguments: f.kind === "parse"
+                ? f.failure.input
+                : JSON.stringify(f.validation.data),
             },
-          ],
-        } satisfies OpenAI.ChatCompletionAssistantMessageParam,
-        {
-          role: "tool",
-          content: JSON.stringify(f.validation.errors),
-          tool_call_id: f.id,
-        } satisfies OpenAI.ChatCompletionToolMessageParam,
-        {
-          role: "system",
-          content: [
-            "You A.I. assistant has composed wrong typed arguments.",
-            "",
-            "Correct it at the next function calling.",
-          ].join("\n"),
-        } satisfies OpenAI.ChatCompletionSystemMessageParam,
+          },
+        ],
+      } satisfies OpenAI.ChatCompletionAssistantMessageParam,
+      {
+        role: "tool",
+        tool_call_id: f.id,
+        content: f.kind === "parse"
+          ? dedent`
+              Invalid JSON format.
+
+              Here is the detailed parsing failure information,
+              including error messages and their locations within the input:
+
+              \`\`\`json
+              ${JSON.stringify(f.failure.errors)}
+              \`\`\`
+
+              And here is the partially parsed data that was successfully
+              extracted before the error occurred:
+
+              \`\`\`json
+              ${JSON.stringify(f.failure.data)}
+              \`\`\`
+            `
+          : [
+              "🚨 VALIDATION FAILURE: Your function arguments do not conform to the required schema.",
+              "",
+              "Each error below is computed absolute truth from rigorous type validation.",
+              "You must fix ALL errors to achieve 100% schema compliance.",
+              "",
+              LlmJson.stringify(f.validation),
+            ].join("\n"),
+      } satisfies OpenAI.ChatCompletionToolMessageParam,
+      {
+        role: "system",
+        content: f.kind === "parse"
+          ? AgenticaSystemPrompt.JSON_PARSE_ERROR.replace(
+              "${{FAILURE}}",
+              JSON.stringify(f.failure),
+            )
+          : AgenticaSystemPrompt.VALIDATE,
+      } satisfies OpenAI.ChatCompletionSystemMessageParam,
     ])
     .flat();
 }

--- a/packages/core/src/orchestrate/cancel.ts
+++ b/packages/core/src/orchestrate/cancel.ts
@@ -221,6 +221,30 @@ async function step(
             name: tc.function.name,
             validation,
           });
+          continue;
+        }
+
+        // FUNCTION EXISTENCE
+        //
+        // `typia` only proves that `name` is a `string`; it cannot know which
+        // functions are currently selected. A name that is not stacked would
+        // otherwise be silently dropped by `cancelFunctionFromContext`, so
+        // report it back to the LLM as an `IValidation.IFailure`.
+        const referenceErrors: IValidation.IError[] = validateFunctionExistence(
+          ctx,
+          validation.data,
+        );
+        if (referenceErrors.length > 0) {
+          failures.push({
+            kind: "validation",
+            id: tc.id,
+            name: tc.function.name,
+            validation: {
+              success: false,
+              data: validation.data,
+              errors: referenceErrors,
+            },
+          });
         }
       }
     }
@@ -326,4 +350,36 @@ function emendMessages(failures: IFailure[]): OpenAI.ChatCompletionMessageParam[
       } satisfies OpenAI.ChatCompletionSystemMessageParam,
     ])
     .flat();
+}
+
+/**
+ * Validate that every function to cancel is actually selected right now.
+ *
+ * `typia` validation only proves that `__IChatFunctionReference.name` is a
+ * `string`; it cannot know which functions are currently stacked. Without this
+ * check a name that is not selected would be silently dropped by
+ * `cancelFunctionFromContext`. The returned errors are fed back to the LLM
+ * through `emendMessages`, exactly like a type validation error - with the
+ * list of cancellable function names in `expected`.
+ */
+function validateFunctionExistence(
+  ctx: AgenticaContext,
+  data: __IChatFunctionReference.IProps,
+): IValidation.IError[] {
+  const cancellable: string[] = ctx.stack.map(s => s.operation.name);
+  const expected: string = cancellable.length === 0
+    ? "never"
+    : cancellable.map(name => JSON.stringify(name)).join(" | ");
+  return data.functions.flatMap((reference, i): IValidation.IError[] =>
+    cancellable.includes(reference.name)
+      ? []
+      : [{
+          path: `$input.functions[${i}].name`,
+          expected,
+          value: reference.name,
+          description: cancellable.length === 0
+            ? `Function "${reference.name}" cannot be cancelled because no function is currently selected.`
+            : `Function "${reference.name}" is not in the current selection, so it cannot be cancelled.`,
+        }],
+  );
 }

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -1,6 +1,8 @@
+import type { IJsonParseResult } from "@typia/interface";
 import type OpenAI from "openai";
 import type { ILlmFunction, IValidation } from "typia";
 
+import { dedent, LlmJson } from "@typia/utils";
 import typia from "typia";
 
 import type { AgenticaContext } from "../context/AgenticaContext";
@@ -28,11 +30,19 @@ const FUNCTION: ILlmFunction = typia.llm.application<
   __IChatSelectFunctionsApplication
 >().functions[0]!;
 
-interface IFailure {
-  id: string;
-  name: string;
-  validation: IValidation.IFailure;
-}
+type IFailure
+  = | {
+    kind: "parse";
+    id: string;
+    name: string;
+    failure: IJsonParseResult.IFailure;
+  }
+  | {
+    kind: "validation";
+    id: string;
+    name: string;
+    validation: IValidation.IFailure;
+  };
 
 export async function select(
   ctx: AgenticaContext,
@@ -241,11 +251,28 @@ async function step(
         if (tc.type !== "function" || tc.function.name !== "selectFunctions") {
           continue;
         }
-        const input: object = FUNCTION.parse(tc.function.arguments) as object;
+        // LENIENT JSON PARSING
+        //
+        // A malformed JSON string is reported back to the LLM as a parse
+        // failure, mirroring `call.ts`. On success the parsed `.data` (never
+        // the `IJsonParseResult` wrapper itself) is forwarded to validation.
+        const parsed: IJsonParseResult<unknown> = FUNCTION.parse(
+          tc.function.arguments,
+        );
+        if (parsed.success === false) {
+          failures.push({
+            kind: "parse",
+            id: tc.id,
+            name: tc.function.name,
+            failure: parsed,
+          });
+          continue;
+        }
         const validation: IValidation<__IChatFunctionReference.IProps>
-          = FUNCTION.validate(input) as IValidation<__IChatFunctionReference.IProps>;
+          = FUNCTION.validate(parsed.data) as IValidation<__IChatFunctionReference.IProps>;
         if (validation.success === false) {
           failures.push({
+            kind: "validation",
             id: tc.id,
             name: tc.function.name,
             validation,
@@ -273,14 +300,17 @@ async function step(
           continue;
         }
 
-        const input: __IChatFunctionReference.IProps | null
-          = typia.json.isParse<__IChatFunctionReference.IProps>(
-            tc.function.arguments,
-          );
-        if (input === null) {
+        // Reuse the lenient parser + validator so that arguments accepted
+        // by the VALIDATION retry above are processed consistently here.
+        const parsed: IJsonParseResult<unknown> = FUNCTION.parse(
+          tc.function.arguments,
+        );
+        const validation: IValidation<__IChatFunctionReference.IProps>
+          = FUNCTION.validate(parsed.data) as IValidation<__IChatFunctionReference.IProps>;
+        if (validation.success === false) {
           continue;
         }
-        for (const reference of input.functions) {
+        for (const reference of validation.data.functions) {
           selectFunctionFromContext(
             ctx,
             reference,
@@ -303,23 +333,51 @@ function emendMessages(failures: IFailure[]): OpenAI.ChatCompletionMessageParam[
             id: f.id,
             function: {
               name: f.name,
-              arguments: JSON.stringify(f.validation.data),
+              arguments: f.kind === "parse"
+                ? f.failure.input
+                : JSON.stringify(f.validation.data),
             },
           },
         ],
       } satisfies OpenAI.ChatCompletionAssistantMessageParam,
       {
         role: "tool",
-        content: JSON.stringify(f.validation.errors),
         tool_call_id: f.id,
+        content: f.kind === "parse"
+          ? dedent`
+              Invalid JSON format.
+
+              Here is the detailed parsing failure information,
+              including error messages and their locations within the input:
+
+              \`\`\`json
+              ${JSON.stringify(f.failure.errors)}
+              \`\`\`
+
+              And here is the partially parsed data that was successfully
+              extracted before the error occurred:
+
+              \`\`\`json
+              ${JSON.stringify(f.failure.data)}
+              \`\`\`
+            `
+          : [
+              "🚨 VALIDATION FAILURE: Your function arguments do not conform to the required schema.",
+              "",
+              "Each error below is computed absolute truth from rigorous type validation.",
+              "You must fix ALL errors to achieve 100% schema compliance.",
+              "",
+              LlmJson.stringify(f.validation),
+            ].join("\n"),
       } satisfies OpenAI.ChatCompletionToolMessageParam,
       {
         role: "system",
-        content: [
-          "You A.I. assistant has composed wrong typed arguments.",
-          "",
-          "Correct it at the next function calling.",
-        ].join("\n"),
+        content: f.kind === "parse"
+          ? AgenticaSystemPrompt.JSON_PARSE_ERROR.replace(
+              "${{FAILURE}}",
+              JSON.stringify(f.failure),
+            )
+          : AgenticaSystemPrompt.VALIDATE,
       } satisfies OpenAI.ChatCompletionSystemMessageParam,
     ])
     .flat();

--- a/packages/core/src/orchestrate/select.ts
+++ b/packages/core/src/orchestrate/select.ts
@@ -277,6 +277,31 @@ async function step(
             name: tc.function.name,
             validation,
           });
+          continue;
+        }
+
+        // FUNCTION EXISTENCE
+        //
+        // `typia` only proves that `name` is a `string`; it cannot know which
+        // functions exist at runtime. A hallucinated name would otherwise be
+        // silently dropped by `selectFunctionFromContext`, so report it back
+        // to the LLM as an `IValidation.IFailure`, just like a type error.
+        const referenceErrors: IValidation.IError[] = validateFunctionExistence(
+          ctx,
+          operations,
+          validation.data,
+        );
+        if (referenceErrors.length > 0) {
+          failures.push({
+            kind: "validation",
+            id: tc.id,
+            name: tc.function.name,
+            validation: {
+              success: false,
+              data: validation.data,
+              errors: referenceErrors,
+            },
+          });
         }
       }
     }
@@ -381,4 +406,37 @@ function emendMessages(failures: IFailure[]): OpenAI.ChatCompletionMessageParam[
       } satisfies OpenAI.ChatCompletionSystemMessageParam,
     ])
     .flat();
+}
+
+/**
+ * Validate that every selected function actually exists.
+ *
+ * `typia` validation only proves that `__IChatFunctionReference.name` is a
+ * `string`; it cannot know which functions exist at runtime. Without this
+ * check a hallucinated name would be silently dropped by
+ * `selectFunctionFromContext`. The returned errors are fed back to the LLM
+ * through `emendMessages`, exactly like a type validation error - with the
+ * list of valid function names in `expected`.
+ */
+function validateFunctionExistence(
+  ctx: AgenticaContext,
+  candidates: AgenticaOperation[],
+  data: __IChatFunctionReference.IProps,
+): IValidation.IError[] {
+  const expected: string = candidates
+    .map(op => JSON.stringify(op.name))
+    .join(" | ");
+  return data.functions.flatMap((reference, i): IValidation.IError[] =>
+    ctx.operations.flat.has(reference.name)
+      ? []
+      : [{
+          path: `$input.functions[${i}].name`,
+          expected,
+          value: reference.name,
+          description: [
+            `Function "${reference.name}" does not exist.`,
+            "Select only from the functions provided by getApiFunctions().",
+          ].join(" "),
+        }],
+  );
 }

--- a/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
+++ b/packages/core/src/utils/ChatGptCompletionMessageUtil.ts
@@ -95,13 +95,13 @@ function accumulate(origin: ChatCompletion, chunk: ChatCompletionChunk): ChatCom
   };
 }
 
-function merge(chunks: ChatCompletionChunk[]): ChatCompletion {
+function mergeChunks(chunks: ChatCompletionChunk[]): ChatCompletion {
   const firstChunk = chunks[0];
   if (firstChunk === undefined) {
     throw new Error("No chunks received");
   }
 
-  const result = chunks.reduce(accumulate, {
+  return chunks.reduce(accumulate, {
     id: firstChunk.id,
     choices: [],
     created: firstChunk.created,
@@ -111,17 +111,29 @@ function merge(chunks: ChatCompletionChunk[]): ChatCompletion {
     service_tier: firstChunk.service_tier,
     system_fingerprint: firstChunk.system_fingerprint,
   } as ChatCompletion);
+}
 
-  // post-process
-  result.choices?.forEach((choice) => {
+/**
+ * Replace any tool call's empty `arguments` with `"{}"`.
+ *
+ * MUST only be applied to a final, fully streamed completion. Running it while
+ * more chunks may still arrive would seed `"{}"` into a not-yet-complete tool
+ * call, and the remaining streamed argument chunks would then be appended onto
+ * it - corrupting the arguments into `{}{...}`.
+ */
+function fixEmptyToolArguments(completion: ChatCompletion): ChatCompletion {
+  completion.choices?.forEach((choice) => {
     choice.message.tool_calls?.filter(tc => tc.type === "function").forEach((toolCall) => {
       if (toolCall.function.arguments === "") {
         toolCall.function.arguments = "{}";
       }
     });
   });
+  return completion;
+}
 
-  return result;
+function merge(chunks: ChatCompletionChunk[]): ChatCompletion {
+  return fixEmptyToolArguments(mergeChunks(chunks));
 }
 
 function mergeChoice(acc: ChatCompletion.Choice, cur: ChatCompletionChunk.Choice): ChatCompletion.Choice {
@@ -221,6 +233,8 @@ export const ChatGptCompletionMessageUtil = {
   transformCompletionChunk,
   accumulate,
   merge,
+  mergeChunks,
+  fixEmptyToolArguments,
   mergeChoice,
   mergeToolCalls,
 };

--- a/packages/core/src/utils/ChatGptCompletionStreamingUtil.ts
+++ b/packages/core/src/utils/ChatGptCompletionStreamingUtil.ts
@@ -56,7 +56,11 @@ async function reduceStreamingWithDispatch(stream: ReadableStream<ChatCompletion
     };
     if (acc.object === "chat.completion.chunk") {
       registerContext([acc, chunk].flatMap(v => v.choices ?? []));
-      return ChatGptCompletionMessageUtil.merge([acc, chunk]);
+      // Use `mergeChunks`, NOT `merge`: `merge` runs the empty-arguments
+      // fixup, which mid-stream seeds a still-incomplete tool call with "{}"
+      // so the remaining streamed argument chunks append onto it (`{}{...}`).
+      // The fixup is applied once, to the final completion, below.
+      return ChatGptCompletionMessageUtil.mergeChunks([acc, chunk]);
     }
     registerContext(chunk.choices ?? []);
     return ChatGptCompletionMessageUtil.accumulate(acc, chunk);
@@ -85,7 +89,7 @@ async function reduceStreamingWithDispatch(stream: ReadableStream<ChatCompletion
     });
     return completion;
   }
-  return nullableCompletion;
+  return ChatGptCompletionMessageUtil.fixEmptyToolArguments(nullableCompletion);
 }
 
 export { reduceStreamingWithDispatch };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^25.3.0
       version: 25.5.0
     openai:
-      specifier: ^6.15.0
-      version: 6.27.0
+      specifier: ^6.38.0
+      version: 6.38.0
     tstl:
       specifier: ^3.0.0
       version: 3.0.0
@@ -116,7 +116,7 @@ importers:
         version: 16.6.1
       openai:
         specifier: catalog:libs
-        version: 6.27.0(zod@4.3.6)
+        version: 6.38.0(zod@4.3.6)
       sqlite-vec:
         specifier: 0.1.7-alpha.2
         version: 0.1.7-alpha.2
@@ -153,7 +153,7 @@ importers:
         version: link:../core
       openai:
         specifier: catalog:libs
-        version: 6.27.0(zod@4.3.6)
+        version: 6.38.0(zod@4.3.6)
       tstl:
         specifier: catalog:libs
         version: 3.0.0
@@ -214,7 +214,7 @@ importers:
         version: 1.11.13
       openai:
         specifier: catalog:libs
-        version: 6.27.0(zod@4.3.6)
+        version: 6.38.0(zod@4.3.6)
       react-markdown:
         specifier: ^9.0.3
         version: 9.1.0(@types/react@19.0.0)(react@18.3.1)
@@ -357,7 +357,7 @@ importers:
         version: 0.2.1
       openai:
         specifier: catalog:libs
-        version: 6.27.0(zod@4.3.6)
+        version: 6.38.0(zod@4.3.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -521,7 +521,7 @@ importers:
         version: 12.0.3
       openai:
         specifier: catalog:libs
-        version: 6.27.0(zod@4.3.6)
+        version: 6.38.0(zod@4.3.6)
       tgrid:
         specifier: ^1.2.1
         version: 1.2.1
@@ -6064,8 +6064,8 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
-  openai@6.27.0:
-    resolution: {integrity: sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==}
+  openai@6.38.0:
+    resolution: {integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -14123,7 +14123,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.27.0(zod@4.3.6):
+  openai@6.38.0(zod@4.3.6):
     optionalDependencies:
       zod: 4.3.6
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ engineStrict: true
 catalogs:
   libs:
     "@types/node": ^25.3.0
-    openai: ^6.15.0
+    openai: ^6.38.0
     tstl: ^3.0.0
     type-fest: ^4.37.0
     uuid: ^13.0.0


### PR DESCRIPTION
## Summary

Hardens the select/cancel orchestration and the `packages/chat` swagger uploader.

### `fix(core)` — `select.ts` / `cancel.ts` left behind by the typia v12 migration

The typia v12 migration (#534) updated `call.ts` to the new lenient
`IJsonParseResult` API but only mechanically renamed `JsonUtil.parse` →
`FUNCTION.parse` in `select.ts` / `cancel.ts`. Since `FUNCTION.parse()` now
returns an `IJsonParseResult` wrapper (`{ success, data, errors }`), the
`as object` cast hid the fact that the **whole wrapper** was passed to
`FUNCTION.validate()` instead of its `.data`.

Result: validation failed on every select/cancel call, burning all `RETRY`
attempts and feeding garbage back to the LLM via `emendMessages`.

Brought both files to parity with `call.ts`:

- validate the parsed `.data`, never the `IJsonParseResult` wrapper
- distinguish JSON parse failures from type validation failures (discriminated `IFailure` union)
- feed JSON parse failures back to the LLM (`JSON_PARSE_ERROR` prompt + failure detail) — previously absent entirely
- enrich validation feedback with the `VALIDATE` prompt + `LlmJson.stringify` annotated errors
- use the lenient parser in PROCESS COMPLETION instead of strict `typia.json.isParse`, so leniently-accepted arguments are not silently dropped

### `fix(core)` — feed back non-existent function references

`__IChatFunctionReference.name` is typed as plain `string`, so typia validation
cannot tell whether a referenced function actually exists. A hallucinated name
was silently dropped by `selectFunctionFromContext` / `cancelFunctionFromContext`
with no feedback and no retry.

After type validation passes, each referenced name is checked — select against
`ctx.operations.flat`, cancel against the current `ctx.stack`. Unresolved
references become synthetic `IValidation.IError`s (`path` → the offending
`functions[i].name`, valid names listed in `expected`, instruction in
`description`) pushed as an `IValidation.IFailure`, so the existing
validation-feedback path reports them to the LLM and retries within the same
bounded retry budget.

### `fix(chat)` — redundant strict OpenAPI validation in the swagger uploader

`AgenticaChatUploaderMovie` ran its own strict `typia.validate()` against the
union of all OpenAPI document types, rejecting real-world specs that the rest
of the pipeline (`OpenApiConverter` / `HttpLlm`) accepts leniently — surfacing
as an "invalid json" error dialog. It now parses the file and hands it
straight to `OpenApiConverter.upgradeDocument`, with distinct messages for
parse vs. conversion failures.

### `chore(deps)`

Bump `openai` catalog to `^6.38.0`.

## Test plan

- `tsc` full build of `packages/core` — passes
- `tsc -p tsconfig.app.json` of `packages/chat` — passes
- `eslint` on all changed files — passes
- Runtime behaviour of select/cancel orchestration not exercised here (requires live LLM calls).

## Known follow-ups (not in this PR)

- `IFailure`, `emendMessages` and `validateFunctionExistence` are duplicated across `select.ts` / `cancel.ts` — this duplication is what let the #534 regression slip through; extracting a shared helper would prevent recurrence.
- On final retry exhaustion select/cancel still silently drop, whereas `call.ts` surfaces a `success: false` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
